### PR TITLE
히스토리에 프로그래스 바 추가

### DIFF
--- a/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/progressbar/TwoTooGoalAchievementProgressbar.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/progressbar/TwoTooGoalAchievementProgressbar.kt
@@ -18,7 +18,7 @@ import com.mashup.twotoo.presenter.home.model.UserType.ME
 import com.mashup.twotoo.presenter.home.model.UserType.PARTNER
 
 @Composable
-fun HomeGoalAchievement(
+fun TwoTooGoalAchievementProgressbar(
     goalAchieveDataList: List<HomeGoalAchieveData>,
     modifier: Modifier = Modifier,
     isShow: Boolean = true,
@@ -110,7 +110,7 @@ private fun PreviewHomeGoalAchieveRow() {
 @Composable
 private fun PreviewHomeGoalAchievement() {
     TwoTooTheme {
-        HomeGoalAchievement(
+        TwoTooGoalAchievementProgressbar(
             modifier = Modifier.width(203.dp).height(59.dp),
             goalAchieveDataList = listOf(
                 HomeGoalAchieveData("공주", type = PARTNER, 0.7f),

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/progressbar/TwoTooGoalAchievementProgressbar.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/progressbar/TwoTooGoalAchievementProgressbar.kt
@@ -21,25 +21,22 @@ import com.mashup.twotoo.presenter.home.model.UserType.PARTNER
 fun TwoTooGoalAchievementProgressbar(
     goalAchieveDataList: List<HomeGoalAchieveData>,
     modifier: Modifier = Modifier,
-    isShow: Boolean = true,
 ) {
-    if (isShow) {
-        Column(
-            modifier = modifier,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            GoalAchievementRow(
-                modifier = Modifier.fillMaxWidth(),
-                homeGoalAchieveData = goalAchieveDataList[0],
-            )
-            Spacer(
-                modifier = Modifier.height(4.dp),
-            )
-            GoalAchievementRow(
-                modifier = Modifier.fillMaxWidth(),
-                homeGoalAchieveData = goalAchieveDataList[1],
-            )
-        }
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        GoalAchievementRow(
+            modifier = Modifier.fillMaxWidth(),
+            homeGoalAchieveData = goalAchieveDataList[0],
+        )
+        Spacer(
+            modifier = Modifier.height(4.dp),
+        )
+        GoalAchievementRow(
+            modifier = Modifier.fillMaxWidth(),
+            homeGoalAchieveData = goalAchieveDataList[1],
+        )
     }
 }
 

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/history/HistoryComponents.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/history/HistoryComponents.kt
@@ -29,7 +29,7 @@ import com.mashup.twotoo.presenter.history.model.HistoryItemUiModel
 @Composable
 fun OwnerNickNames(partnerNickname: String, myNickname: String) {
     Row(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 67.dp),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 67.dp).padding(top = 37.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         CardText(text = partnerNickname)

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/history/HistoryScreen.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/history/HistoryScreen.kt
@@ -1,11 +1,13 @@
 package com.mashup.twotoo.presenter.history
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -15,9 +17,12 @@ import com.mashup.twotoo.presenter.R
 import com.mashup.twotoo.presenter.designsystem.component.toolbar.TwoTooBackToolbar
 import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
 import com.mashup.twotoo.presenter.history.model.HistoryItemUiModel
+import com.mashup.twotoo.presenter.home.HomeGoalAchievement
+import com.mashup.twotoo.presenter.home.model.HomeGoalAchieveData
+import com.mashup.twotoo.presenter.home.model.UserType
 
 @Composable
-fun HistoryScreen(historyItemUiModels: List<HistoryItemUiModel> = listOf()) {
+fun HistoryScreen(historyItemUiModels: List<HistoryItemUiModel> = listOf(), isHomeGoalAchievementShow: Boolean) {
     Scaffold(
         topBar = {
             TwoTooBackToolbar(
@@ -33,13 +38,21 @@ fun HistoryScreen(historyItemUiModels: List<HistoryItemUiModel> = listOf()) {
         },
         containerColor = TwoTooTheme.color.backgroundYellow,
     ) {
+        val isHomeGoalAchievementShow by remember { mutableStateOf(isHomeGoalAchievementShow) }
         Column(modifier = Modifier.fillMaxSize().padding(paddingValues = it)) {
             ChallengeInfo(
                 "24",
                 "30분 이상 운동하기",
                 "운동 사진으로 인증하기\n인증 실패하는지 확인",
             )
-            Spacer(modifier = Modifier.height(37.dp))
+            HomeGoalAchievement(
+                modifier = Modifier.padding(top = 12.dp, start = 24.dp).width(210.dp).height(59.dp).background(color = Color.White, shape = RoundedCornerShape(15.dp)),
+                goalAchieveDataList = listOf(
+                    HomeGoalAchieveData(name = "공주", type = UserType.PARTNER, progress = 0.7f),
+                    HomeGoalAchieveData(name = "나", type = UserType.ME, progress = 0.6f),
+                ),
+                isShow = isHomeGoalAchievementShow,
+            )
             OwnerNickNames("왕자", "공주")
             Spacer(modifier = Modifier.height(12.dp))
             Divider(
@@ -58,7 +71,7 @@ fun HistoryScreen(historyItemUiModels: List<HistoryItemUiModel> = listOf()) {
 @Composable
 private fun PreviewHistoryScreen() {
     TwoTooTheme {
-        HistoryScreen(HistoryItemUiModel.generateDummyHistoryItemsToPreView())
+        HistoryScreen(HistoryItemUiModel.generateDummyHistoryItemsToPreView(), isHomeGoalAchievementShow = false)
     }
 }
 
@@ -66,6 +79,14 @@ private fun PreviewHistoryScreen() {
 @Composable
 private fun PreviewHistoryScreenEmpty() {
     TwoTooTheme {
-        HistoryScreen(HistoryItemUiModel.generateDummyEmptyHistoryItemsToPreView())
+        HistoryScreen(HistoryItemUiModel.generateDummyEmptyHistoryItemsToPreView(), isHomeGoalAchievementShow = false)
+    }
+}
+
+@Preview(name = "프로그래스바가 보이는 화면")
+@Composable
+private fun PreviewHistoryScreenWithProgressBar() {
+    TwoTooTheme {
+        HistoryScreen(HistoryItemUiModel.generateDummyHistoryItemsToPreView(), isHomeGoalAchievementShow = true)
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/history/HistoryScreen.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/history/HistoryScreen.kt
@@ -17,7 +17,7 @@ import com.mashup.twotoo.presenter.R
 import com.mashup.twotoo.presenter.designsystem.component.toolbar.TwoTooBackToolbar
 import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
 import com.mashup.twotoo.presenter.history.model.HistoryItemUiModel
-import com.mashup.twotoo.presenter.home.HomeGoalAchievement
+import com.mashup.twotoo.presenter.home.TwoTooGoalAchievementProgressbar
 import com.mashup.twotoo.presenter.home.model.HomeGoalAchieveData
 import com.mashup.twotoo.presenter.home.model.UserType
 
@@ -45,7 +45,7 @@ fun HistoryScreen(historyItemUiModels: List<HistoryItemUiModel> = listOf(), isHo
                 "30분 이상 운동하기",
                 "운동 사진으로 인증하기\n인증 실패하는지 확인",
             )
-            HomeGoalAchievement(
+            TwoTooGoalAchievementProgressbar(
                 modifier = Modifier.padding(top = 12.dp, start = 24.dp).width(210.dp).height(59.dp).background(color = Color.White, shape = RoundedCornerShape(15.dp)),
                 goalAchieveDataList = listOf(
                     HomeGoalAchieveData(name = "공주", type = UserType.PARTNER, progress = 0.7f),

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/history/HistoryScreen.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/history/HistoryScreen.kt
@@ -38,21 +38,23 @@ fun HistoryScreen(historyItemUiModels: List<HistoryItemUiModel> = listOf(), isHo
         },
         containerColor = TwoTooTheme.color.backgroundYellow,
     ) {
-        val isHomeGoalAchievementShow by remember { mutableStateOf(isHomeGoalAchievementShow) }
         Column(modifier = Modifier.fillMaxSize().padding(paddingValues = it)) {
             ChallengeInfo(
                 "24",
                 "30분 이상 운동하기",
                 "운동 사진으로 인증하기\n인증 실패하는지 확인",
             )
-            TwoTooGoalAchievementProgressbar(
-                modifier = Modifier.padding(top = 12.dp, start = 24.dp).width(210.dp).height(59.dp).background(color = Color.White, shape = RoundedCornerShape(15.dp)),
-                goalAchieveDataList = listOf(
-                    HomeGoalAchieveData(name = "공주", type = UserType.PARTNER, progress = 0.7f),
-                    HomeGoalAchieveData(name = "나", type = UserType.ME, progress = 0.6f),
-                ),
-                isShow = isHomeGoalAchievementShow,
-            )
+            if (isHomeGoalAchievementShow) {
+                TwoTooGoalAchievementProgressbar(
+                    modifier = Modifier.padding(top = 12.dp, start = 24.dp).width(210.dp)
+                        .height(59.dp)
+                        .background(color = Color.White, shape = RoundedCornerShape(15.dp)),
+                    goalAchieveDataList = listOf(
+                        HomeGoalAchieveData(name = "공주", type = UserType.PARTNER, progress = 0.7f),
+                        HomeGoalAchieveData(name = "나", type = UserType.ME, progress = 0.6f),
+                    ),
+                )
+            }
             OwnerNickNames("왕자", "공주")
             Spacer(modifier = Modifier.height(12.dp))
             Divider(

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/home/Home.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/home/Home.kt
@@ -68,7 +68,7 @@ fun HomeScreen(
                 },
                 homeGoalFieldData = HomeGoalFieldData(),
             )
-            HomeGoalAchievement(
+            TwoTooGoalAchievementProgressbar(
                 modifier = Modifier.width(210.dp).height(59.dp).constrainAs(goalAchievement) {
                     start.linkTo(homeGoalField.start)
                     top.linkTo(homeGoalField.bottom)

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/home/HomeGoalAchievement.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/home/HomeGoalAchievement.kt
@@ -21,22 +21,25 @@ import com.mashup.twotoo.presenter.home.model.UserType.PARTNER
 fun HomeGoalAchievement(
     goalAchieveDataList: List<HomeGoalAchieveData>,
     modifier: Modifier = Modifier,
+    isShow: Boolean = true,
 ) {
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        GoalAchievementRow(
-            modifier = Modifier.fillMaxWidth(),
-            homeGoalAchieveData = goalAchieveDataList[0],
-        )
-        Spacer(
-            modifier = Modifier.height(4.dp),
-        )
-        GoalAchievementRow(
-            modifier = Modifier.fillMaxWidth(),
-            homeGoalAchieveData = goalAchieveDataList[1],
-        )
+    if (isShow) {
+        Column(
+            modifier = modifier,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            GoalAchievementRow(
+                modifier = Modifier.fillMaxWidth(),
+                homeGoalAchieveData = goalAchieveDataList[0],
+            )
+            Spacer(
+                modifier = Modifier.height(4.dp),
+            )
+            GoalAchievementRow(
+                modifier = Modifier.fillMaxWidth(),
+                homeGoalAchieveData = goalAchieveDataList[1],
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## 🔥 관련 이슈

close #57 

## 🔥 PR Point

- 히스토리에 프로그래스 바 추가
- 공통 컴포넌트로 분리

## 🔥 To Reviewers
```kotlin 
@Composable
fun HistoryScreen(historyItemUiModels: List<HistoryItemUiModel> = listOf(), isHomeGoalAchievementShow: Boolean) {

val isHomeGoalAchievementShow by remember { mutableStateOf(isHomeGoalAchievementShow) } 

}
```
요러면  NAME_SHADOWING 경고 뜨는데 보통 초기화를 위한 param 이름을 변수와 분리할때 어떻게 네이밍 하는지 궁금합니다~
검색해도 딱히 안나오네용

## 📷 Screenshot

![image](https://github.com/mash-up-kr/TwoToo_Android/assets/23455686/bccf1116-21ae-4e93-8367-938c930f73d7)

