### PR TITLE
온보딩, 챌린지 생성 Navigation

### DIFF
--- a/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/CreateChallenge.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/CreateChallenge.kt
@@ -10,6 +10,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.paint
 import androidx.compose.ui.layout.ContentScale
@@ -24,12 +28,24 @@ import com.mashup.twotoo.presenter.designsystem.component.toolbar.TwoTooBackTool
 import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
 
 @Composable
-fun CreateChallenge(
-    stepNumber: Int,
-    currentStepScreen: @Composable () -> Unit,
+fun CreateChallengeRoute(
+    onFinishChallengeInfo: () -> Unit
 ) {
+    CreateChallenge(onFinishChallengeInfo)
+}
+
+@Composable
+fun CreateChallenge(
+    onFinishChallengeInfo: () -> Unit = {}
+) {
+    var currentStep by remember { mutableStateOf(1) }
+
     Scaffold(
-        topBar = { TwoTooBackToolbar(onClickBackIcon = {}) },
+        topBar = {
+            TwoTooBackToolbar(onClickBackIcon = {
+                if (currentStep > 1) currentStep--
+            })
+        },
     ) { padding ->
         Box(
             modifier = Modifier
@@ -42,10 +58,11 @@ fun CreateChallenge(
         ) {
             Column(
                 modifier = Modifier
-                    .fillMaxSize().padding(horizontal = 24.dp),
+                    .fillMaxSize()
+                    .padding(horizontal = 24.dp),
             ) {
                 Text(
-                    text = stringResource(id = R.string.create_challenge_step, stepNumber),
+                    text = stringResource(id = R.string.create_challenge_step, currentStep),
                     textAlign = TextAlign.Left,
                     style = TwoTooTheme.typography.headLineNormal28,
                     color = TwoTooTheme.color.mainBrown,
@@ -56,7 +73,16 @@ fun CreateChallenge(
                     color = TwoTooTheme.color.gray600,
                     modifier = Modifier.padding(top = 12.dp),
                 )
-                currentStepScreen()
+
+                when (currentStep) {
+                    1 -> CreateChallengeOneStep()
+                    2 -> CreateChallengeTwoStep()
+                    3 -> CreateChallengeCard(
+                        "하루 운동 30분 이상 하기",
+                        "2023/05/01 ~ 5/22",
+                        "운동사진으로 인증하기\n실패하는 사람은 뷔페 쏘기",
+                    )
+                }
 
                 Spacer(Modifier.weight(1f))
                 TwoTooTextButton(
@@ -65,7 +91,13 @@ fun CreateChallenge(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(57.dp),
-                ) {}
+                ) {
+                    if (currentStep == 3) {
+                        onFinishChallengeInfo()
+                    } else {
+                        currentStep++
+                    }
+                }
                 Spacer(modifier = Modifier.height(55.dp))
             }
         }
@@ -75,27 +107,5 @@ fun CreateChallenge(
 @Preview
 @Composable
 private fun PreviewCreateChallengeOneStep() {
-    CreateChallenge(stepNumber = 1) {
-        CreateChallengeOneStep()
-    }
-}
-
-@Preview
-@Composable
-private fun PreviewCreateChallengeTwoStep() {
-    CreateChallenge(stepNumber = 2) {
-        CreateChallengeTwoStep()
-    }
-}
-
-@Preview
-@Composable
-private fun PreviewCreateChallengeThreeStep() {
-    CreateChallenge(stepNumber = 3) {
-        CreateChallengeCard(
-            "하루 운동 30분 이상 하기",
-            "2023/05/01 ~ 5/22",
-            "운동사진으로 인증하기\n실패하는 사람은 뷔페 쏘기",
-        )
-    }
+    CreateChallenge()
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/SelectFlowerCard.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/SelectFlowerCard.kt
@@ -28,7 +28,16 @@ import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
 import com.mashup.twotoo.presenter.designsystem.theme.TwotooPink
 
 @Composable
-fun SelectFlowerCard() {
+fun SelectFlowerCardRoute(
+    onStartButtonClick: () -> Unit
+) {
+    SelectFlowerCard(onStartButtonClick)
+}
+
+@Composable
+fun SelectFlowerCard(
+    onStartButtonClick: () -> Unit = {}
+) {
     Scaffold(
         topBar = { TwoTooBackToolbar(onClickBackIcon = {}) },
     ) { padding ->
@@ -53,7 +62,9 @@ fun SelectFlowerCard() {
                     .fillMaxWidth()
                     .height(57.dp)
                     .align(Alignment.BottomCenter),
-            ) {}
+            ) {
+                onStartButtonClick()
+            }
         }
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/navigation/CreateChallengeNavigation.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/navigation/CreateChallengeNavigation.kt
@@ -6,37 +6,40 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.mashup.twotoo.presenter.createChallenge.CreateChallenge
-import com.mashup.twotoo.presenter.createChallenge.SelectFlowerCard
 import com.mashup.twotoo.presenter.createChallenge.SelectFlowerCardRoute
 import com.mashup.twotoo.presenter.createChallenge.SuccessChallengeRequest
-
-sealed class CreateChallengeNavigation(val route: String) {
-    object CreateChallenge : CreateChallengeNavigation("create_challenge")
-    object SelectFlowerCard : CreateChallengeNavigation("select_flower_card")
-    object SuccessChallengeRequest : CreateChallengeNavigation("success_challenge_request")
-}
+import com.mashup.twotoo.presenter.navigation.NavigationRoute
 
 fun NavController.navigateToCreateChallenge(navOptions: NavOptions? = null) {
-    this.navigate(route = CreateChallengeNavigation.CreateChallenge.route, navOptions = navOptions)
+    this.navigate(route = NavigationRoute.CreateChallengeGraph.route, navOptions = navOptions)
 }
+
+private fun NavController.navigateToSelectFlowerCard(navOptions: NavOptions? = null) {
+    this.navigate(route = NavigationRoute.CreateChallengeGraph.SelectFlowerCardScreen.route, navOptions = navOptions)
+}
+
+private fun NavController.navigateToSuccessChallengeRequest(navOptions: NavOptions? = null) {
+    this.navigate(route = NavigationRoute.CreateChallengeGraph.route, navOptions = navOptions)
+}
+
 fun NavGraphBuilder.createChallengeGraph(
     navController: NavController
 ) {
     navigation(
-        startDestination = CreateChallengeNavigation.CreateChallenge.route,
-        route = "CreateChallengeNavigation",
+        startDestination = NavigationRoute.CreateChallengeGraph.CreateChallengeScreen.route,
+        route = NavigationRoute.CreateChallengeGraph.route,
     ) {
-        composable(route = CreateChallengeNavigation.CreateChallenge.route) {
+        composable(route = NavigationRoute.CreateChallengeGraph.CreateChallengeScreen.route) {
             CreateChallenge {
-                navController.navigate(CreateChallengeNavigation.SelectFlowerCard.route)
+                navController.navigateToSelectFlowerCard()
             }
         }
-        composable(route = CreateChallengeNavigation.SelectFlowerCard.route) {
+        composable(route = NavigationRoute.CreateChallengeGraph.SelectFlowerCardScreen.route) {
             SelectFlowerCardRoute {
-                navController.navigate(CreateChallengeNavigation.SuccessChallengeRequest.route)
+                navController.navigateToSuccessChallengeRequest()
             }
         }
-        composable(route = CreateChallengeNavigation.SuccessChallengeRequest.route) {
+        composable(route = NavigationRoute.CreateChallengeGraph.SuccessChallengeRequest.route) {
             SuccessChallengeRequest()
         }
     }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/navigation/CreateChallengeNavigation.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/navigation/CreateChallengeNavigation.kt
@@ -9,7 +9,6 @@ import com.mashup.twotoo.presenter.createChallenge.CreateChallenge
 import com.mashup.twotoo.presenter.createChallenge.SelectFlowerCard
 import com.mashup.twotoo.presenter.createChallenge.SelectFlowerCardRoute
 import com.mashup.twotoo.presenter.createChallenge.SuccessChallengeRequest
-import com.mashup.twotoo.presenter.home.navigation.HomeNavigationRoute
 
 sealed class CreateChallengeNavigation(val route: String) {
     object CreateChallenge : CreateChallengeNavigation("create_challenge")
@@ -25,7 +24,7 @@ fun NavGraphBuilder.createChallengeGraph(
 ) {
     navigation(
         startDestination = CreateChallengeNavigation.CreateChallenge.route,
-        route = HomeNavigationRoute,
+        route = "CreateChallengeNavigation",
     ) {
         composable(route = CreateChallengeNavigation.CreateChallenge.route) {
             CreateChallenge {

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/navigation/CreateChallengeNavigation.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/navigation/CreateChallengeNavigation.kt
@@ -1,0 +1,44 @@
+package com.mashup.twotoo.presenter.createChallenge.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import androidx.navigation.navigation
+import com.mashup.twotoo.presenter.createChallenge.CreateChallenge
+import com.mashup.twotoo.presenter.createChallenge.SelectFlowerCard
+import com.mashup.twotoo.presenter.createChallenge.SelectFlowerCardRoute
+import com.mashup.twotoo.presenter.createChallenge.SuccessChallengeRequest
+import com.mashup.twotoo.presenter.home.navigation.HomeNavigationRoute
+
+sealed class CreateChallengeNavigation(val route: String) {
+    object CreateChallenge : CreateChallengeNavigation("create_challenge")
+    object SelectFlowerCard : CreateChallengeNavigation("select_flower_card")
+    object SuccessChallengeRequest : CreateChallengeNavigation("success_challenge_request")
+}
+
+fun NavController.navigateToCreateChallenge(navOptions: NavOptions? = null) {
+    this.navigate(route = CreateChallengeNavigation.CreateChallenge.route, navOptions = navOptions)
+}
+fun NavGraphBuilder.createChallengeGraph(
+    navController: NavController
+) {
+    navigation(
+        startDestination = CreateChallengeNavigation.CreateChallenge.route,
+        route = HomeNavigationRoute,
+    ) {
+        composable(route = CreateChallengeNavigation.CreateChallenge.route) {
+            CreateChallenge {
+                navController.navigate(CreateChallengeNavigation.SelectFlowerCard.route)
+            }
+        }
+        composable(route = CreateChallengeNavigation.SelectFlowerCard.route) {
+            SelectFlowerCardRoute {
+                navController.navigate(CreateChallengeNavigation.SuccessChallengeRequest.route)
+            }
+        }
+        composable(route = CreateChallengeNavigation.SuccessChallengeRequest.route) {
+            SuccessChallengeRequest()
+        }
+    }
+}

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/recommendChallenge/RecommendChanllengeContent.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/recommendChallenge/RecommendChanllengeContent.kt
@@ -5,8 +5,11 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
@@ -25,10 +28,13 @@ import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
 
 @Composable
 fun RecommendChallengeContent() {
+    val verticalScrollState = rememberScrollState()
     Column(
         modifier = Modifier
-            .fillMaxSize()
+            .fillMaxWidth()
+            .fillMaxHeight(0.9f)
             .padding(bottom = 30.dp)
+            .verticalScroll(verticalScrollState)
             .background(color = BackgroundYellow),
         verticalArrangement = Arrangement.SpaceBetween,
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -53,6 +59,7 @@ fun RecommendButtonItem(recommendName: Int) {
     val color = if (isPressed) TwoTooTheme.color.mainYellow else TwoTooTheme.color.mainWhite
 
     Button(
+        modifier = Modifier.padding(vertical = 8.dp),
         shape = TwoTooTheme.shape.medium,
         interactionSource = interactionSource,
         colors = ButtonDefaults.buttonColors(containerColor = color),

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/invite/SendInvitation.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/invite/SendInvitation.kt
@@ -26,14 +26,14 @@ import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
 
 @Composable
 fun SendInvitationRoute(
-    sendInvitationButtonClick: () -> Unit
+    sendInvitationButtonClick: () -> Unit = {}
 ) {
     SendInvitation(sendInvitationButtonClick)
 }
 
 @Composable
 fun SendInvitation(
-    sendInvitationButtonClick: () -> Unit
+    sendInvitationButtonClick: () -> Unit = {}
 ) {
     Scaffold(
         topBar = { TwoTooMainToolbar() },
@@ -80,5 +80,5 @@ fun SendInvitation(
 @Preview
 @Composable
 private fun SendInvitationPreview() {
-    SendInvitation({})
+    SendInvitation()
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/invite/SendInvitation.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/invite/SendInvitation.kt
@@ -25,7 +25,16 @@ import com.mashup.twotoo.presenter.designsystem.component.toolbar.TwoTooMainTool
 import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
 
 @Composable
-fun SendInvitation() {
+fun SendInvitationRoute(
+    sendInvitationButtonClick: () -> Unit
+) {
+    SendInvitation(sendInvitationButtonClick)
+}
+
+@Composable
+fun SendInvitation(
+    sendInvitationButtonClick: () -> Unit
+) {
     Scaffold(
         topBar = { TwoTooMainToolbar() },
     ) { padding ->
@@ -59,7 +68,9 @@ fun SendInvitation() {
                 Spacer(modifier = Modifier.weight(1f))
                 TwoTooTextButton(
                     text = stringResource(id = R.string.send_invite),
-                ) {}
+                ) {
+                    sendInvitationButtonClick()
+                }
                 Spacer(modifier = Modifier.height(55.dp))
             }
         }
@@ -69,5 +80,5 @@ fun SendInvitation() {
 @Preview
 @Composable
 private fun SendInvitationPreview() {
-    SendInvitation()
+    SendInvitation({})
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/invite/WaitingAcceptPair.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/invite/WaitingAcceptPair.kt
@@ -27,6 +27,11 @@ import com.mashup.twotoo.presenter.designsystem.component.toolbar.TwoTooMainTool
 import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
 
 @Composable
+fun WaitingAcceptPairRoute() {
+    WaitingAcceptPair()
+}
+
+@Composable
 fun WaitingAcceptPair() {
     Scaffold(
         topBar = { TwoTooMainToolbar() },
@@ -47,7 +52,7 @@ fun WaitingAcceptPair() {
                 verticalArrangement = Arrangement.SpaceBetween,
             ) {
                 Text(
-                    modifier = Modifier.padding(top = 150.dp, bottom = 13.dp),
+                    modifier = Modifier.padding(top = 120.dp, bottom = 13.dp),
                     text = stringResource(id = R.string.invite_waiting_other),
                     textAlign = TextAlign.Center,
                     style = TwoTooTheme.typography.headLineNormal28,
@@ -74,7 +79,6 @@ fun WaitingAcceptPair() {
 @Composable
 fun WaitingInviteBottom() {
     Column(
-        modifier = Modifier.padding(vertical = 55.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(18.dp),
     ) {

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/invite/navigation/InviteNavigation.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/invite/navigation/InviteNavigation.kt
@@ -21,7 +21,7 @@ fun NavGraphBuilder.invitationGraph(
 ) {
     navigation(
         startDestination = InvitationNavigation.SendInvitation.route,
-        route = "",
+        route = "SendInvitation",
     ) {
         composable(route = InvitationNavigation.SendInvitation.route) {
             SendInvitationRoute { navController.navigate(InvitationNavigation.WaitingAcceptPair.route) }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/invite/navigation/InviteNavigation.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/invite/navigation/InviteNavigation.kt
@@ -7,26 +7,26 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.mashup.twotoo.presenter.invite.SendInvitationRoute
 import com.mashup.twotoo.presenter.invite.WaitingAcceptPairRoute
-
-sealed class InvitationNavigation(val route: String) {
-    object SendInvitation : InvitationNavigation("invitation_route")
-    object WaitingAcceptPair : InvitationNavigation("waiting_accept_route")
-}
+import com.mashup.twotoo.presenter.navigation.NavigationRoute
 
 fun NavController.navigateToInvitation(navOptions: NavOptions? = null) {
-    this.navigate(route = InvitationNavigation.SendInvitation.route, navOptions = navOptions)
+    this.navigate(route = NavigationRoute.InvitationGraph.route, navOptions = navOptions)
+}
+
+private fun NavController.navigateToWaitingAcceptPair(navOptions: NavOptions? = null) {
+    this.navigate(route = NavigationRoute.InvitationGraph.route, navOptions = navOptions)
 }
 fun NavGraphBuilder.invitationGraph(
     navController: NavController
 ) {
     navigation(
-        startDestination = InvitationNavigation.SendInvitation.route,
-        route = "SendInvitation",
+        startDestination = NavigationRoute.InvitationGraph.SendInvitationScreen.route,
+        route = NavigationRoute.InvitationGraph.route,
     ) {
-        composable(route = InvitationNavigation.SendInvitation.route) {
-            SendInvitationRoute { navController.navigate(InvitationNavigation.WaitingAcceptPair.route) }
+        composable(route = NavigationRoute.InvitationGraph.SendInvitationScreen.route) {
+            SendInvitationRoute { navController.navigateToWaitingAcceptPair() }
         }
-        composable(route = InvitationNavigation.WaitingAcceptPair.route) {
+        composable(route = NavigationRoute.InvitationGraph.WaitingAcceptPairScreen.route) {
             WaitingAcceptPairRoute()
         }
     }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/invite/navigation/InviteNavigation.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/invite/navigation/InviteNavigation.kt
@@ -1,0 +1,33 @@
+package com.mashup.twotoo.presenter.invite.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import androidx.navigation.navigation
+import com.mashup.twotoo.presenter.invite.SendInvitationRoute
+import com.mashup.twotoo.presenter.invite.WaitingAcceptPairRoute
+
+sealed class InvitationNavigation(val route: String) {
+    object SendInvitation : InvitationNavigation("invitation_route")
+    object WaitingAcceptPair : InvitationNavigation("waiting_accept_route")
+}
+
+fun NavController.navigateToInvitation(navOptions: NavOptions? = null) {
+    this.navigate(route = InvitationNavigation.SendInvitation.route, navOptions = navOptions)
+}
+fun NavGraphBuilder.invitationGraph(
+    navController: NavController
+) {
+    navigation(
+        startDestination = InvitationNavigation.SendInvitation.route,
+        route = "",
+    ) {
+        composable(route = InvitationNavigation.SendInvitation.route) {
+            SendInvitationRoute { navController.navigate(InvitationNavigation.WaitingAcceptPair.route) }
+        }
+        composable(route = InvitationNavigation.WaitingAcceptPair.route) {
+            WaitingAcceptPairRoute()
+        }
+    }
+}

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/navigation/TopLevelDestination.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/navigation/TopLevelDestination.kt
@@ -26,3 +26,21 @@ enum class TopLevelDestination(
         buttonTitleTextId = R.string.user_nav_button,
     ),
 }
+
+sealed class NavigationRoute(val route: String) {
+    object OnBoardingGraph : NavigationRoute("onboarding") {
+        object OnboardingScreen : NavigationRoute("onboarding/screen")
+    }
+    object NickNameSettingGraph : NavigationRoute("nickNameSetting") {
+        object NickNameSettingScreen : NavigationRoute("nickNameSetting/screen")
+    }
+    object InvitationGraph : NavigationRoute("invitation") {
+        object SendInvitationScreen : NavigationRoute("sendInvitation/screen")
+        object WaitingAcceptPairScreen : NavigationRoute("waitingAccept/screen")
+    }
+    object CreateChallengeGraph : NavigationRoute("createChallenge") {
+        object CreateChallengeScreen : NavigationRoute("createChallenge/screen")
+        object SelectFlowerCardScreen : NavigationRoute("selectFlowerCard/screen")
+        object SuccessChallengeRequest : NavigationRoute("successChallengeRequest/screen")
+    }
+}

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/navigation/TwoTooNavHost.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/navigation/TwoTooNavHost.kt
@@ -4,13 +4,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import com.mashup.twotoo.presenter.createChallenge.navigation.createChallengeGraph
-import com.mashup.twotoo.presenter.createChallenge.navigation.navigateToCreateChallenge
 import com.mashup.twotoo.presenter.garden.navigation.gardenGraph
 import com.mashup.twotoo.presenter.home.navigation.HomeNavigationRoute
 import com.mashup.twotoo.presenter.home.navigation.homeGraph
 import com.mashup.twotoo.presenter.invite.navigation.invitationGraph
 import com.mashup.twotoo.presenter.invite.navigation.navigateToInvitation
-import com.mashup.twotoo.presenter.onboarding.navigation.OnBoardingRoute
 import com.mashup.twotoo.presenter.onboarding.navigation.navigateToOnNickNameSetting
 import com.mashup.twotoo.presenter.onboarding.navigation.onBoardingGraph
 import com.mashup.twotoo.presenter.onboarding.navigation.onNickNameSettingGraph

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/navigation/TwoTooNavHost.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/navigation/TwoTooNavHost.kt
@@ -3,7 +3,10 @@ package com.mashup.twotoo.presenter.navigation
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
+import com.mashup.twotoo.presenter.createChallenge.navigation.createChallengeGraph
+import com.mashup.twotoo.presenter.createChallenge.navigation.navigateToCreateChallenge
 import com.mashup.twotoo.presenter.garden.navigation.gardenGraph
+import com.mashup.twotoo.presenter.home.navigation.HomeNavigationRoute
 import com.mashup.twotoo.presenter.home.navigation.homeGraph
 import com.mashup.twotoo.presenter.invite.navigation.invitationGraph
 import com.mashup.twotoo.presenter.invite.navigation.navigateToInvitation
@@ -18,7 +21,7 @@ import com.mashup.twotoo.presenter.user.navigation.userGraph
 fun TwoTooNavHost(
     appState: TwoTooAppState,
     modifier: Modifier = Modifier,
-    startDestination: String = OnBoardingRoute,
+    startDestination: String = HomeNavigationRoute,
 ) {
     val navController = appState.navController
     NavHost(
@@ -36,5 +39,6 @@ fun TwoTooNavHost(
             navController.navigateToInvitation()
         }
         invitationGraph(navController)
+        createChallengeGraph(navController)
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/navigation/TwoTooNavHost.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/navigation/TwoTooNavHost.kt
@@ -35,6 +35,6 @@ fun TwoTooNavHost(
         onNickNameSettingGraph {
             navController.navigateToInvitation()
         }
-        invitationGraph()
+        invitationGraph(navController)
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/navigation/TwoTooNavHost.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/navigation/TwoTooNavHost.kt
@@ -4,9 +4,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import com.mashup.twotoo.presenter.garden.navigation.gardenGraph
-import com.mashup.twotoo.presenter.home.navigation.HomeNavigationRoute
 import com.mashup.twotoo.presenter.home.navigation.homeGraph
+import com.mashup.twotoo.presenter.invite.navigation.invitationGraph
+import com.mashup.twotoo.presenter.invite.navigation.navigateToInvitation
+import com.mashup.twotoo.presenter.onboarding.navigation.OnBoardingRoute
+import com.mashup.twotoo.presenter.onboarding.navigation.navigateToOnNickNameSetting
 import com.mashup.twotoo.presenter.onboarding.navigation.onBoardingGraph
+import com.mashup.twotoo.presenter.onboarding.navigation.onNickNameSettingGraph
 import com.mashup.twotoo.presenter.ui.TwoTooAppState
 import com.mashup.twotoo.presenter.user.navigation.userGraph
 
@@ -14,7 +18,7 @@ import com.mashup.twotoo.presenter.user.navigation.userGraph
 fun TwoTooNavHost(
     appState: TwoTooAppState,
     modifier: Modifier = Modifier,
-    startDestination: String = HomeNavigationRoute,
+    startDestination: String = OnBoardingRoute,
 ) {
     val navController = appState.navController
     NavHost(
@@ -25,6 +29,12 @@ fun TwoTooNavHost(
         gardenGraph()
         homeGraph()
         userGraph()
-        onBoardingGraph()
+        onBoardingGraph {
+            navController.navigateToOnNickNameSetting()
+        }
+        onNickNameSettingGraph {
+            navController.navigateToInvitation()
+        }
+        invitationGraph()
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/onboarding/NickNameSetting.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/onboarding/NickNameSetting.kt
@@ -38,8 +38,16 @@ import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
 import com.mashup.twotoo.presenter.designsystem.theme.TwotooPink
 
 @Composable
+fun NickNameSettingRoute(
+    onNextButtonClick: () -> Unit,
+) {
+    NickNameSetting(onNextButtonClick)
+}
+
+@Composable
 fun NickNameSetting(
-    otherNickName: String?
+    onNextButtonClick: () -> Unit,
+    otherNickName: String? = null
 ) {
     Scaffold(
         topBar = { TwoTooMainToolbar() },
@@ -73,8 +81,10 @@ fun NickNameSetting(
                 Spacer(modifier = Modifier.weight(1f))
                 TwoTooTextButton(
                     text = stringResource(id = R.string.button_confirm),
-                    enabled = false,
-                ) {}
+                    enabled = true,
+                ) {
+                    onNextButtonClick()
+                }
                 Spacer(modifier = Modifier.height(55.dp))
             }
         }
@@ -147,5 +157,5 @@ private fun InviteGuidePreview() {
 @Preview
 @Composable
 private fun NickNameSettingPreview() {
-    NickNameSetting("공주")
+    NickNameSetting({},"공주")
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/onboarding/OnBoarding.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/onboarding/OnBoarding.kt
@@ -23,11 +23,12 @@ import com.google.accompanist.pager.rememberPagerState
 import com.mashup.twotoo.presenter.R
 import com.mashup.twotoo.presenter.designsystem.component.button.TwoTooIconButtonImpl
 import com.mashup.twotoo.presenter.designsystem.component.toolbar.TwoTooMainToolbar
+import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
 import com.mashup.twotoo.presenter.sdk.theme.KakaoLoginButtonTheme
 
 @Composable
 fun OnBoardingRoute(
-    onClickLoginButton: () -> Unit
+    onClickLoginButton: () -> Unit = {}
 ) {
     OnBoardingScreen(onClickLoginButton)
 }
@@ -35,7 +36,7 @@ fun OnBoardingRoute(
 @OptIn(ExperimentalPagerApi::class)
 @Composable
 fun OnBoardingScreen(
-    onClickLoginButton: () -> Unit
+    onClickLoginButton: () -> Unit = {}
 ) {
     val pagerState = rememberPagerState()
     Scaffold(
@@ -77,6 +78,7 @@ fun KakaoLoginButton(
             Text(
                 stringResource(id = KakaoLoginButtonTheme.TextId),
                 color = KakaoLoginButtonTheme.ContentColor,
+                style = TwoTooTheme.typography.headLineNormal18,
             )
         },
         iconId = KakaoLoginButtonTheme.IconId,
@@ -90,5 +92,5 @@ fun KakaoLoginButton(
 @Preview
 @Composable
 private fun OnBoardingPagerPreview() {
-    OnBoardingScreen({})
+    OnBoardingScreen()
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/onboarding/OnBoarding.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/onboarding/OnBoarding.kt
@@ -26,13 +26,17 @@ import com.mashup.twotoo.presenter.designsystem.component.toolbar.TwoTooMainTool
 import com.mashup.twotoo.presenter.sdk.theme.KakaoLoginButtonTheme
 
 @Composable
-fun OnBoardingRoute() {
-    OnBoardingScreen()
+fun OnBoardingRoute(
+    onClickLoginButton: () -> Unit
+) {
+    OnBoardingScreen(onClickLoginButton)
 }
 
 @OptIn(ExperimentalPagerApi::class)
 @Composable
-fun OnBoardingScreen() {
+fun OnBoardingScreen(
+    onClickLoginButton: () -> Unit
+) {
     val pagerState = rememberPagerState()
     Scaffold(
         topBar = { TwoTooMainToolbar() },
@@ -56,7 +60,7 @@ fun OnBoardingScreen() {
 
                 Spacer(modifier = Modifier.weight(1f))
                 if (pagerState.currentPage == MAX_COUNT - 1) {
-                    KakaoLoginButton()
+                    KakaoLoginButton(onClickLoginButton)
                     Spacer(modifier = Modifier.height(56.dp))
                 }
             }
@@ -65,7 +69,9 @@ fun OnBoardingScreen() {
 }
 
 @Composable
-fun KakaoLoginButton() {
+fun KakaoLoginButton(
+    onClickLoginButton: () -> Unit
+) {
     TwoTooIconButtonImpl(
         text = {
             Text(
@@ -76,11 +82,13 @@ fun KakaoLoginButton() {
         iconId = KakaoLoginButtonTheme.IconId,
         buttonColor = KakaoLoginButtonTheme.ContainerColor,
         buttonRadius = KakaoLoginButtonTheme.Radius,
-    ) {}
+    ) {
+        onClickLoginButton()
+    }
 }
 
 @Preview
 @Composable
 private fun OnBoardingPagerPreview() {
-    OnBoardingScreen()
+    OnBoardingScreen({})
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/onboarding/navigation/NickNameSettingNavigation.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/onboarding/navigation/NickNameSettingNavigation.kt
@@ -1,0 +1,20 @@
+package com.mashup.twotoo.presenter.onboarding.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import com.mashup.twotoo.presenter.onboarding.NickNameSettingRoute
+
+const val NickNameSettingRoute: String = "nickname_route"
+
+fun NavController.navigateToOnNickNameSetting(navOptions: NavOptions? = null) {
+    this.navigate(route = NickNameSettingRoute, navOptions = navOptions)
+}
+fun NavGraphBuilder.onNickNameSettingGraph(
+    onNextButtonClick: () -> Unit
+) {
+    composable(route = NickNameSettingRoute) {
+        NickNameSettingRoute(onNextButtonClick)
+    }
+}

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/onboarding/navigation/NickNameSettingNavigation.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/onboarding/navigation/NickNameSettingNavigation.kt
@@ -4,17 +4,16 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import com.mashup.twotoo.presenter.navigation.NavigationRoute
 import com.mashup.twotoo.presenter.onboarding.NickNameSettingRoute
 
-const val NickNameSettingRoute: String = "nickname_route"
-
 fun NavController.navigateToOnNickNameSetting(navOptions: NavOptions? = null) {
-    this.navigate(route = NickNameSettingRoute, navOptions = navOptions)
+    this.navigate(route = NavigationRoute.NickNameSettingGraph.route, navOptions = navOptions)
 }
 fun NavGraphBuilder.onNickNameSettingGraph(
     onNextButtonClick: () -> Unit
 ) {
-    composable(route = NickNameSettingRoute) {
+    composable(route = NavigationRoute.NickNameSettingGraph.NickNameSettingScreen.route) {
         NickNameSettingRoute(onNextButtonClick)
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/onboarding/navigation/OnBoardingNavigation.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/onboarding/navigation/OnBoardingNavigation.kt
@@ -4,17 +4,16 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import com.mashup.twotoo.presenter.navigation.NavigationRoute
 import com.mashup.twotoo.presenter.onboarding.OnBoardingRoute
 
-const val OnBoardingRoute: String = "onboarding_route"
-
 fun NavController.navigateToOnBoarding(navOptions: NavOptions? = null) {
-    this.navigate(route = OnBoardingRoute, navOptions = navOptions)
+    this.navigate(route = NavigationRoute.OnBoardingGraph.route, navOptions = navOptions)
 }
 fun NavGraphBuilder.onBoardingGraph(
     onClickLoginButton: () -> Unit
 ) {
-    composable(route = OnBoardingRoute) {
+    composable(route = NavigationRoute.OnBoardingGraph.OnboardingScreen.route) {
         OnBoardingRoute(onClickLoginButton)
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/onboarding/navigation/OnBoardingNavigation.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/onboarding/navigation/OnBoardingNavigation.kt
@@ -11,8 +11,10 @@ const val OnBoardingRoute: String = "onboarding_route"
 fun NavController.navigateToOnBoarding(navOptions: NavOptions? = null) {
     this.navigate(route = OnBoardingRoute, navOptions = navOptions)
 }
-fun NavGraphBuilder.onBoardingGraph() {
+fun NavGraphBuilder.onBoardingGraph(
+    onClickLoginButton: () -> Unit
+) {
     composable(route = OnBoardingRoute) {
-        OnBoardingRoute()
+        OnBoardingRoute(onClickLoginButton)
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/sdk/theme/KakaoLoginButtonTheme.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/sdk/theme/KakaoLoginButtonTheme.kt
@@ -10,9 +10,9 @@ import com.mashup.twotoo.presenter.R
 object KakaoLoginButtonTheme {
     val ContainerColor = Color(0xFFFEE500)
     val ContentColor = Color(0xFF000000)
-    val Radius = RoundedCornerShape(12.dp)
+    val Radius = RoundedCornerShape(20.dp)
 
-    @StringRes val TextId: Int = R.string.kakaoLogin
+    @StringRes val TextId: Int = R.string.login_title
 
     @DrawableRes val IconId: Int = R.drawable.kakaotalk
 }

--- a/presenter/src/main/res/values/string.xml
+++ b/presenter/src/main/res/values/string.xml
@@ -11,7 +11,7 @@
     <string name="bottom_navigation_bar">바텀 네비게이션</string>
     
     <!-- Kakao Login -->
-    <string name= "login_tite">카카오톡으로 로그인</string>
+    <string name= "login_title">카카오톡으로 로그인</string>
     <string name="failureKakaoTalkLogin">카카오톡으로 로그인 실패</string>
     <string name="successKakaoTalkLogin">카카오톡으로 로그인 성공</string>
     <string name= "kakaoLogin">카카오 로그인</string>


### PR DESCRIPTION
## 🔥 관련 이슈
close #73 

## 🔥 PR Point
- 온보딩 3단계 -> 닉네임 설정 -> 초대장 보내기 -> 대기중 
- 챌린지 생성1단계 -> 2단계 -> 3단계 -> 꽃 선택 -> 생성 성공

## 🔥 To Reviewers
잘한지 모르겠어요..맞게했는지도 모르겠고..리뷰 부탁드려요ㅠ
우선 `NavGraphBuilder.graph` 이게 하나의 그래프고 그 안에 연결되는 navigation으로 
이해해서 아래 방식으로 묶을 수 있는건 하나의 그래프안에 넣어두었어요!
```kotlin
sealed class InvitationNavigation(val route: String) {
    object SendInvitation : InvitationNavigation("invitation_route")
    object WaitingAcceptPair : InvitationNavigation("waiting_accept_route")
}

fun NavController.navigateToInvitation(navOptions: NavOptions? = null) {
    this.navigate(route = InvitationNavigation.SendInvitation.route, navOptions = navOptions)
}
fun NavGraphBuilder.invitationGraph(
    navController: NavController
) {
    navigation(
        startDestination = InvitationNavigation.SendInvitation.route,
        route = "SendInvitation",
    ) {
        composable(route = InvitationNavigation.SendInvitation.route) {
            SendInvitationRoute { navController.navigate(InvitationNavigation.WaitingAcceptPair.route) }
        }
        composable(route = InvitationNavigation.WaitingAcceptPair.route) {
            WaitingAcceptPairRoute()
        }
    }
}
```
- 온보딩이나 챌린지 생성은 bottomnavigation이 필요하지 않는데 이거에 대한 분기처리는 
  혜진언니가 코드를 짠 것 같아서 conflict를 방지하기 위해 우선 노출되도록 납뒀어요!
- 아무래도..TwoTooNavHost를 막 바꿨다간 머지할 때 큰일날 것 같아서 공통으로 건드린 부분은 추가만 하고 수정은 안했어요..!!
- 온보딩 이미지는 영상때매 넣었는데 다음 pr에서 디자인 리소스 한번에 정리하려고 해당 Pr엔 포함 안시켰어요~!

## 📷 Screenshot
|기능|스크린샷|
|:---|---|
|온보딩|https://github.com/mash-up-kr/TwoToo_Android/assets/53086454/7875899e-7edf-412c-bcc6-763eebfd47b1|
|챌린지 생성|https://github.com/mash-up-kr/TwoToo_Android/assets/53086454/fb999f62-f23c-4597-b884-efbe2c0c6ffb|
