### PR TITLE
화면 사이즈에 따른 꽃 크기 조정

### DIFF
--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/both/HomeOngoingBothAuthTest.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/both/HomeOngoingBothAuthTest.kt
@@ -3,6 +3,7 @@ package com.mashup.twotoo.presenter.home.ongoingChallenge.auth.both
 import android.content.Context
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -24,6 +25,8 @@ class HomeOngoingBothAuthTest {
     val composeTestRule = createComposeRule()
 
     private lateinit var context: Context
+    private var screenHeight: Int = 0
+    private var screenWidth: Int = 0
 
     /**
      * * 첫번째 챌린지 일때 텍스트 테스트
@@ -55,7 +58,7 @@ class HomeOngoingBothAuthTest {
     ) {
         (challengeStateTypeUiModel.homeChallengeStateUiModel.challengeStateUiModel as HomeFlowerPartnerAndMeUiModel).also {
             Truth.assertThat(
-                it.partner.flowerType.getFlowerImage(context).image,
+                it.partner.flowerType.getFlowerImage(context, screenWidth, screenHeight).image,
             ).isEqualTo(
                 when (partnerStage) {
                     Stage.Zero -> R.drawable.img_home_zero_stage_partner
@@ -68,7 +71,7 @@ class HomeOngoingBothAuthTest {
             )
 
             Truth.assertThat(
-                it.me.flowerType.getFlowerImage(context).image,
+                it.me.flowerType.getFlowerImage(context, screenWidth, screenHeight).image,
             ).isEqualTo(
                 when (meStage) {
                     Stage.Zero -> R.drawable.img_home_zero_stage_me
@@ -121,6 +124,8 @@ class HomeOngoingBothAuthTest {
         )
         composeTestRule.setContent {
             context = LocalContext.current
+            screenHeight = LocalConfiguration.current.screenHeightDp
+            screenWidth = LocalConfiguration.current.screenWidthDp
             TwoTooTheme {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/doNotBoth/HomeOngoingDoNotAuthBothTest.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/doNotBoth/HomeOngoingDoNotAuthBothTest.kt
@@ -3,6 +3,7 @@ package com.mashup.twotoo.presenter.home.ongoingChallenge.auth.doNotBoth
 import android.content.Context
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -25,6 +26,8 @@ class HomeOngoingDoNotAuthBothTest {
     val composeTestRule = createComposeRule()
 
     private lateinit var context: Context
+    private var screenHeight: Int = 0
+    private var screenWidth: Int = 0
 
     /**
      * * 첫번째 챌린지 일때 텍스트 테스트
@@ -56,7 +59,7 @@ class HomeOngoingDoNotAuthBothTest {
     ) {
         (challengeStateTypeUiModel.homeChallengeStateUiModel.challengeStateUiModel as HomeFlowerPartnerAndMeUiModel).also {
             Truth.assertThat(
-                it.partner.flowerType.getFlowerImage(context).image,
+                it.partner.flowerType.getFlowerImage(context,screenWidth, screenHeight).image,
             ).isEqualTo(
                 when (partnerStage) {
                     Stage.Zero -> R.drawable.img_home_zero_stage_partner
@@ -69,7 +72,7 @@ class HomeOngoingDoNotAuthBothTest {
             )
 
             Truth.assertThat(
-                it.me.flowerType.getFlowerImage(context).image,
+                it.me.flowerType.getFlowerImage(context,screenWidth, screenHeight).image,
             ).isEqualTo(
                 when (meStage) {
                     Stage.Zero -> R.drawable.img_home_zero_stage_me
@@ -122,6 +125,8 @@ class HomeOngoingDoNotAuthBothTest {
         )
         composeTestRule.setContent {
             context = LocalContext.current
+            screenHeight = LocalConfiguration.current.screenHeightDp
+            screenWidth = LocalConfiguration.current.screenWidthDp
             TwoTooTheme {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/firstCreateChallenge/HomeOngoingFirstChallengeTest.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/firstCreateChallenge/HomeOngoingFirstChallengeTest.kt
@@ -3,6 +3,7 @@ package com.mashup.twotoo.presenter.home.ongoingChallenge.auth.firstCreateChalle
 import android.content.Context
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -13,14 +14,14 @@ import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
 import com.mashup.twotoo.presenter.home.HomeScreen
 import com.mashup.twotoo.presenter.home.model.AuthType
 import com.mashup.twotoo.presenter.home.model.ChallengeState
+import com.mashup.twotoo.presenter.home.model.Flower
 import com.mashup.twotoo.presenter.home.model.HomeChallengeStateUiModel
 import com.mashup.twotoo.presenter.home.model.HomeFlowerPartnerAndMeUiModel
 import com.mashup.twotoo.presenter.home.model.HomeFlowerUiModel
 import com.mashup.twotoo.presenter.home.model.OngoingChallengeUiModel
 import com.mashup.twotoo.presenter.home.model.UserType
-import com.mashup.twotoo.presenter.home.model.flower.Flower
-import com.mashup.twotoo.presenter.home.model.flower.FlowerName
-import com.mashup.twotoo.presenter.home.model.flower.Stage
+import com.mashup.twotoo.presenter.model.FlowerName
+import com.mashup.twotoo.presenter.model.Stage
 import org.junit.Rule
 import org.junit.Test
 
@@ -30,6 +31,8 @@ class HomeOngoingFirstChallengeTest {
     val composeTestRule = createComposeRule()
 
     private lateinit var context: Context
+    private var screenHeight: Int = 0
+    private var screenWidth: Int = 0
 
     @Test
     fun 챌린지_생성후_FirstCreateChallenge일때() {
@@ -42,6 +45,8 @@ class HomeOngoingFirstChallengeTest {
 
         composeTestRule.setContent {
             context = LocalContext.current
+            screenHeight = LocalConfiguration.current.screenHeightDp
+            screenWidth = LocalConfiguration.current.screenWidthDp
             TwoTooTheme {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),
@@ -60,11 +65,11 @@ class HomeOngoingFirstChallengeTest {
 
         (challengeStateTypeUiModel.homeChallengeStateUiModel.challengeStateUiModel as HomeFlowerPartnerAndMeUiModel).also {
             Truth.assertThat(
-                it.partner.flowerType.getFlowerImage(context).image,
+                it.partner.flowerType.getFlowerImage(context, screenWidth, screenHeight).image,
             ).isEqualTo(R.drawable.img_home_zero_stage_partner)
 
             Truth.assertThat(
-                it.me.flowerType.getFlowerImage(context).image,
+                it.me.flowerType.getFlowerImage(context, screenWidth, screenHeight).image,
             ).isEqualTo(R.drawable.img_home_zero_stage_me)
         }
         Thread.sleep(3000)
@@ -111,11 +116,11 @@ class HomeOngoingFirstChallengeTest {
 
         (challengeStateTypeUiModel.homeChallengeStateUiModel.challengeStateUiModel as HomeFlowerPartnerAndMeUiModel).also {
             Truth.assertThat(
-                it.partner.flowerType.getFlowerImage(context).image,
+                it.partner.flowerType.getFlowerImage(context, screenWidth, screenHeight).image,
             ).isEqualTo(R.drawable.img_home_first_stage_partner)
 
             Truth.assertThat(
-                it.me.flowerType.getFlowerImage(context).image,
+                it.me.flowerType.getFlowerImage(context, screenWidth, screenHeight).image,
             ).isEqualTo(R.drawable.img_home_zero_stage_me)
         }
         Thread.sleep(3000)

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/onlyMe/HomeOngoingAuthOnlyMeTest.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/onlyMe/HomeOngoingAuthOnlyMeTest.kt
@@ -3,6 +3,7 @@ package com.mashup.twotoo.presenter.home.ongoingChallenge.auth.onlyMe
 import android.content.Context
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -25,6 +26,8 @@ class HomeOngoingAuthOnlyMeTest {
     val composeTestRule = createComposeRule()
 
     private lateinit var context: Context
+    private var screenHeight: Int = 0
+    private var screenWidth: Int = 0
 
     /**
      * * 첫번째 챌린지 일때 텍스트 테스트
@@ -56,7 +59,7 @@ class HomeOngoingAuthOnlyMeTest {
     ) {
         (challengeStateTypeUiModel.homeChallengeStateUiModel.challengeStateUiModel as HomeFlowerPartnerAndMeUiModel).also {
             Truth.assertThat(
-                it.partner.flowerType.getFlowerImage(context).image,
+                it.partner.flowerType.getFlowerImage(context, screenWidth, screenHeight).image,
             ).isEqualTo(
                 when (partnerStage) {
                     Stage.Zero -> R.drawable.img_home_zero_stage_partner
@@ -69,7 +72,7 @@ class HomeOngoingAuthOnlyMeTest {
             )
 
             Truth.assertThat(
-                it.me.flowerType.getFlowerImage(context).image,
+                it.me.flowerType.getFlowerImage(context, screenWidth, screenHeight).image,
             ).isEqualTo(
                 when (meStage) {
                     Stage.Zero -> R.drawable.img_home_zero_stage_me
@@ -122,6 +125,8 @@ class HomeOngoingAuthOnlyMeTest {
         )
         composeTestRule.setContent {
             context = LocalContext.current
+            screenHeight = LocalConfiguration.current.screenHeightDp
+            screenWidth = LocalConfiguration.current.screenWidthDp
             TwoTooTheme {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/onlyPartner/HomeOngoingAuthOnlyPartnerTest.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/onlyPartner/HomeOngoingAuthOnlyPartnerTest.kt
@@ -3,6 +3,7 @@ package com.mashup.twotoo.presenter.home.ongoingChallenge.auth.onlyPartner
 import android.content.Context
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -15,7 +16,7 @@ import com.mashup.twotoo.presenter.home.model.HomeChallengeStateUiModel
 import com.mashup.twotoo.presenter.home.model.HomeFlowerPartnerAndMeUiModel
 import com.mashup.twotoo.presenter.home.model.HomeFlowerUiModel
 import com.mashup.twotoo.presenter.home.model.OngoingChallengeUiModel
-import com.mashup.twotoo.presenter.home.model.flower.Stage
+import com.mashup.twotoo.presenter.model.Stage
 import org.junit.Rule
 import org.junit.Test
 
@@ -25,6 +26,8 @@ class HomeOngoingAuthOnlyPartnerTest {
     val composeTestRule = createComposeRule()
 
     private lateinit var context: Context
+    private var screenHeight: Int = 0
+    private var screenWidth: Int = 0
 
     /**
      * * 첫번째 챌린지 일때 텍스트 테스트
@@ -56,7 +59,7 @@ class HomeOngoingAuthOnlyPartnerTest {
     ) {
         (challengeStateTypeUiModel.homeChallengeStateUiModel.challengeStateUiModel as HomeFlowerPartnerAndMeUiModel).also {
             Truth.assertThat(
-                it.partner.flowerType.getFlowerImage(context).image,
+                it.partner.flowerType.getFlowerImage(context, screenWidth, screenHeight).image,
             ).isEqualTo(
                 when (partnerStage) {
                     Stage.Zero -> R.drawable.img_home_zero_stage_partner
@@ -69,7 +72,7 @@ class HomeOngoingAuthOnlyPartnerTest {
             )
 
             Truth.assertThat(
-                it.me.flowerType.getFlowerImage(context).image,
+                it.me.flowerType.getFlowerImage(context, screenWidth, screenHeight).image,
             ).isEqualTo(
                 when (meStage) {
                     Stage.Zero -> R.drawable.img_home_zero_stage_me
@@ -122,6 +125,8 @@ class HomeOngoingAuthOnlyPartnerTest {
         )
         composeTestRule.setContent {
             context = LocalContext.current
+            screenHeight = LocalConfiguration.current.screenHeightDp
+            screenWidth = LocalConfiguration.current.screenWidthDp
             TwoTooTheme {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/cheer/both/HomeCheerBothTest.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/cheer/both/HomeCheerBothTest.kt
@@ -3,6 +3,7 @@ package com.mashup.twotoo.presenter.home.ongoingChallenge.cheer.both
 import android.content.Context
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -10,7 +11,6 @@ import com.google.common.truth.Truth
 import com.mashup.twotoo.presenter.R
 import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
 import com.mashup.twotoo.presenter.home.HomeScreen
-import com.mashup.twotoo.presenter.home.model.AuthType
 import com.mashup.twotoo.presenter.home.model.CheerState
 import com.mashup.twotoo.presenter.home.model.CheerWithFlower
 import com.mashup.twotoo.presenter.home.model.HomeChallengeStateUiModel
@@ -27,6 +27,8 @@ class HomeCheerBothTest {
     val composeTestRule = createComposeRule()
 
     private lateinit var context: Context
+    private var screenHeight: Int = 0
+    private var screenWidth: Int = 0
 
     /**
      * 상대방과 내가 응원을 했을 때 상태입니다.
@@ -80,7 +82,7 @@ class HomeCheerBothTest {
     ) {
         (challengeStateTypeUiModel.homeChallengeStateUiModel.challengeStateUiModel as HomeCheerUiModel).also {
             Truth.assertThat(
-                it.partner.homeFlowerUiModel.flowerType.getFlowerImage(context).image,
+                it.partner.homeFlowerUiModel.flowerType.getFlowerImage(context, screenWidth, screenHeight).image,
             ).isEqualTo(
                 when (partnerStage) {
                     Stage.Zero -> R.drawable.img_home_zero_stage_partner
@@ -93,7 +95,7 @@ class HomeCheerBothTest {
             )
 
             Truth.assertThat(
-                it.me.homeFlowerUiModel.flowerType.getFlowerImage(context).image,
+                it.me.homeFlowerUiModel.flowerType.getFlowerImage(context, screenWidth, screenHeight).image,
             ).isEqualTo(
                 when (meStage) {
                     Stage.Zero -> R.drawable.img_home_zero_stage_me
@@ -149,6 +151,8 @@ class HomeCheerBothTest {
         )
         composeTestRule.setContent {
             context = LocalContext.current
+            screenHeight = LocalConfiguration.current.screenHeightDp
+            screenWidth = LocalConfiguration.current.screenWidthDp
             TwoTooTheme {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/cheer/doNotBoth/HomeCheerDoNotBothTest.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/cheer/doNotBoth/HomeCheerDoNotBothTest.kt
@@ -3,6 +3,7 @@ package com.mashup.twotoo.presenter.home.ongoingChallenge.cheer.doNotBoth
 import android.content.Context
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -10,7 +11,6 @@ import com.google.common.truth.Truth
 import com.mashup.twotoo.presenter.R
 import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
 import com.mashup.twotoo.presenter.home.HomeScreen
-import com.mashup.twotoo.presenter.home.model.AuthType
 import com.mashup.twotoo.presenter.home.model.CheerState
 import com.mashup.twotoo.presenter.home.model.CheerWithFlower
 import com.mashup.twotoo.presenter.home.model.HomeChallengeStateUiModel
@@ -27,6 +27,8 @@ class HomeCheerDoNotBothTest {
     val composeTestRule = createComposeRule()
 
     private lateinit var context: Context
+    private var screenHeight: Int = 0
+    private var screenWidth: Int = 0
 
     /**
      * 상대방과 내가 둘다 응원을 하지 않았을 때 상태입니다.
@@ -81,7 +83,7 @@ class HomeCheerDoNotBothTest {
     ) {
         (challengeStateTypeUiModel.homeChallengeStateUiModel.challengeStateUiModel as HomeCheerUiModel).also {
             Truth.assertThat(
-                it.partner.homeFlowerUiModel.flowerType.getFlowerImage(context).image,
+                it.partner.homeFlowerUiModel.flowerType.getFlowerImage(context, screenWidth, screenHeight).image,
             ).isEqualTo(
                 when (partnerStage) {
                     Stage.Zero -> R.drawable.img_home_zero_stage_partner
@@ -94,7 +96,7 @@ class HomeCheerDoNotBothTest {
             )
 
             Truth.assertThat(
-                it.me.homeFlowerUiModel.flowerType.getFlowerImage(context).image,
+                it.me.homeFlowerUiModel.flowerType.getFlowerImage(context, screenWidth, screenHeight).image,
             ).isEqualTo(
                 when (meStage) {
                     Stage.Zero -> R.drawable.img_home_zero_stage_me
@@ -150,6 +152,8 @@ class HomeCheerDoNotBothTest {
         )
         composeTestRule.setContent {
             context = LocalContext.current
+            screenHeight = LocalConfiguration.current.screenHeightDp
+            screenWidth = LocalConfiguration.current.screenWidthDp
             TwoTooTheme {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/cheer/onlyMe/HomeCheerOnlyMeTest.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/cheer/onlyMe/HomeCheerOnlyMeTest.kt
@@ -3,6 +3,7 @@ package com.mashup.twotoo.presenter.home.ongoingChallenge.cheer.onlyMe
 import android.content.Context
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -26,6 +27,9 @@ class HomeCheerOnlyMeTest {
     val composeTestRule = createComposeRule()
 
     private lateinit var context: Context
+    private var screenHeight: Int = 0
+    private var screenWidth: Int = 0
+
 
     /**
      * 나만 응원을 했을 때 상태입니다.
@@ -80,7 +84,7 @@ class HomeCheerOnlyMeTest {
     ) {
         (challengeStateTypeUiModel.homeChallengeStateUiModel.challengeStateUiModel as HomeCheerUiModel).also {
             Truth.assertThat(
-                it.partner.homeFlowerUiModel.flowerType.getFlowerImage(context).image,
+                it.partner.homeFlowerUiModel.flowerType.getFlowerImage(context,screenWidth, screenHeight).image,
             ).isEqualTo(
                 when (partnerStage) {
                     Stage.Zero -> R.drawable.img_home_zero_stage_partner
@@ -93,7 +97,7 @@ class HomeCheerOnlyMeTest {
             )
 
             Truth.assertThat(
-                it.me.homeFlowerUiModel.flowerType.getFlowerImage(context).image,
+                it.me.homeFlowerUiModel.flowerType.getFlowerImage(context,screenWidth, screenHeight).image,
             ).isEqualTo(
                 when (meStage) {
                     Stage.Zero -> R.drawable.img_home_zero_stage_me
@@ -149,6 +153,8 @@ class HomeCheerOnlyMeTest {
         )
         composeTestRule.setContent {
             context = LocalContext.current
+            screenHeight = LocalConfiguration.current.screenHeightDp
+            screenWidth = LocalConfiguration.current.screenWidthDp
             TwoTooTheme {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/cheer/onlyPartner/HomeCheerOnlyPartner.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/cheer/onlyPartner/HomeCheerOnlyPartner.kt
@@ -83,7 +83,7 @@ class HomeCheerOnlyPartner {
     ) {
         (challengeStateTypeUiModel.homeChallengeStateUiModel.challengeStateUiModel as HomeCheerUiModel).also {
             Truth.assertThat(
-                it.partner.homeFlowerUiModel.flowerType.getFlowerImage(context,screenWidth, screenHeight).image,
+                it.partner.homeFlowerUiModel.flowerType.getFlowerImage(context, screenWidth, screenHeight).image,
             ).isEqualTo(
                 when (partnerStage) {
                     Stage.Zero -> R.drawable.img_home_zero_stage_partner
@@ -96,7 +96,7 @@ class HomeCheerOnlyPartner {
             )
 
             Truth.assertThat(
-                it.me.homeFlowerUiModel.flowerType.getFlowerImage(context,screenWidth, screenHeight).image,
+                it.me.homeFlowerUiModel.flowerType.getFlowerImage(context, screenWidth, screenHeight).image,
             ).isEqualTo(
                 when (meStage) {
                     Stage.Zero -> R.drawable.img_home_zero_stage_me

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/cheer/onlyPartner/HomeCheerOnlyPartner.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/cheer/onlyPartner/HomeCheerOnlyPartner.kt
@@ -3,6 +3,7 @@ package com.mashup.twotoo.presenter.home.ongoingChallenge.cheer.onlyPartner
 import android.content.Context
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -26,6 +27,8 @@ class HomeCheerOnlyPartner {
     val composeTestRule = createComposeRule()
 
     private lateinit var context: Context
+    private var screenHeight: Int = 0
+    private var screenWidth: Int = 0
 
     /**
      * 파트너만 응원을 했을 때 상태입니다.
@@ -80,7 +83,7 @@ class HomeCheerOnlyPartner {
     ) {
         (challengeStateTypeUiModel.homeChallengeStateUiModel.challengeStateUiModel as HomeCheerUiModel).also {
             Truth.assertThat(
-                it.partner.homeFlowerUiModel.flowerType.getFlowerImage(context).image,
+                it.partner.homeFlowerUiModel.flowerType.getFlowerImage(context,screenWidth, screenHeight).image,
             ).isEqualTo(
                 when (partnerStage) {
                     Stage.Zero -> R.drawable.img_home_zero_stage_partner
@@ -93,7 +96,7 @@ class HomeCheerOnlyPartner {
             )
 
             Truth.assertThat(
-                it.me.homeFlowerUiModel.flowerType.getFlowerImage(context).image,
+                it.me.homeFlowerUiModel.flowerType.getFlowerImage(context,screenWidth, screenHeight).image,
             ).isEqualTo(
                 when (meStage) {
                     Stage.Zero -> R.drawable.img_home_zero_stage_me
@@ -149,6 +152,8 @@ class HomeCheerOnlyPartner {
         )
         composeTestRule.setContent {
             context = LocalContext.current
+            screenHeight = LocalConfiguration.current.screenHeightDp
+            screenWidth = LocalConfiguration.current.screenWidthDp
             TwoTooTheme {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/toolbar/TwoTooMainToolbar.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/toolbar/TwoTooMainToolbar.kt
@@ -47,7 +47,7 @@ fun TwoTooMainToolbar(
                 }
             }
         },
-        modifier = modifier.then(Modifier.height(56.dp)),
+        modifier = modifier.then(Modifier.height(44.dp)),
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = Color.Transparent,
         ),

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/garden/GardenComponents.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/garden/GardenComponents.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -92,8 +93,10 @@ private fun BoxScope.Flowers(meFlower: FlowerName, partnerFlower: FlowerName) {
             .padding(bottom = 23.dp),
     ) {
         val context = LocalContext.current
-        val meFlower = FlowerHead(meFlower).getFlowerImage(context)
-        val partnerFlower = FlowerHead(partnerFlower).getFlowerImage(context)
+        val screenWidth = LocalConfiguration.current.screenWidthDp
+        val screenHeight = LocalConfiguration.current.screenHeightDp
+        val meFlower = FlowerHead(meFlower).getFlowerImage(context, screenWidth, screenHeight)
+        val partnerFlower = FlowerHead(partnerFlower).getFlowerImage(context, screenWidth, screenHeight)
         TwoTooImageView(
             modifier = Modifier.size(meFlower.width, meFlower.height),
             model = meFlower.image,

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/garden/model/FlowerHead.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/garden/model/FlowerHead.kt
@@ -9,7 +9,7 @@ import com.mashup.twotoo.presenter.model.FlowerType
 data class FlowerHead(val flowerName: FlowerName) : FlowerType(
     name = flowerName,
 ) {
-    override fun getFlowerImage(context: Context): FlowerImage {
+    override fun getFlowerImage(context: Context, screenWidth: Int, screenHeight: Int): FlowerImage {
         val name = "img_head_${flowerName.name.lowercase()}_sm"
         val image = context.resources.getIdentifier(name, "drawable", context.packageName)
         return FlowerImage(image = image, width = 68.dp, height = 68.dp)

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/home/Home.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/home/Home.kt
@@ -1,6 +1,7 @@
 package com.mashup.twotoo.presenter.home
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
@@ -15,8 +16,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.constraintlayout.compose.Dimension
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import com.mashup.twotoo.presenter.R
@@ -117,31 +116,19 @@ fun HomeScreen(
     state: ChallengeStateTypeUiModel = OngoingChallengeUiModel.default,
     onClickCheerButton: () -> Unit = {},
 ) {
-    ConstraintLayout(
+    Column(
         modifier = modifier.semantics {
             testTagsAsResourceId = true
         },
     ) {
-        val (topBar, homeBeforeChallenge, homeOngoingChallenge) = createRefs()
         TwoTooMainToolbar(
-            modifier = Modifier.constrainAs(topBar) {
-                start.linkTo(parent.start)
-                top.linkTo(parent.top)
-                end.linkTo(parent.end)
-            },
             onClickHelpIcon = {
             },
         )
         when (state) {
             is BeforeChallengeUiModel -> {
                 HomeBeforeChallenge(
-                    modifier = Modifier.constrainAs(homeBeforeChallenge) {
-                        top.linkTo(topBar.bottom)
-                        start.linkTo(parent.start)
-                        end.linkTo(parent.end)
-                        bottom.linkTo(parent.bottom)
-                        height = Dimension.fillToConstraints
-                    },
+                    modifier = Modifier.fillMaxSize(),
                     beforeChallengeUiModel = state,
                     onClickBeforeChallengeTextButton = onClickBeforeChallengeTextButton,
                 )
@@ -149,13 +136,7 @@ fun HomeScreen(
             is OngoingChallengeUiModel -> {
                 HomeOngoingChallenge(
                     navigateToHistory = navigateToHistory,
-                    modifier = Modifier.constrainAs(homeOngoingChallenge) {
-                        top.linkTo(topBar.bottom)
-                        start.linkTo(parent.start)
-                        end.linkTo(parent.end)
-                        bottom.linkTo(parent.bottom)
-                        height = Dimension.fillToConstraints
-                    },
+                    modifier = Modifier.fillMaxSize(),
                     ongoingChallengeUiModel = state,
                     onBeeButtonClick = onBeeButtonClick,
                     onCommit = onCommit,

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/home/model/Flower.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/home/model/Flower.kt
@@ -5,7 +5,9 @@ package com.mashup.twotoo.presenter.home.model
  */
 
 import android.content.Context
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.times
 import com.mashup.twotoo.presenter.R
 import com.mashup.twotoo.presenter.home.model.UserType.ME
 import com.mashup.twotoo.presenter.home.model.UserType.PARTNER
@@ -27,32 +29,33 @@ data class Flower(
 ) : FlowerType(
     name = flowerName,
 ) {
-    override fun getFlowerImage(context: Context): FlowerImage {
+    override fun getFlowerImage(context: Context, screenWidth: Int, screenHeight: Int): FlowerImage {
         return when (userType) {
             ME -> {
                 val name = "img_home_${growType.name.lowercase()}_stage_${flowerName.name.lowercase()}_me"
                 val image = context.resources.getIdentifier(name, "drawable", context.packageName)
-
+                val (width, height) = calculateWidthAndHeight(screenWidth, screenHeight, growType)
                 when (growType) {
-                    Zero -> FlowerImage(image = R.drawable.img_home_zero_stage_me, width = 53.dp, height = 49.dp)
-                    First -> FlowerImage(image = R.drawable.img_home_first_stage_me, width = 76.dp, height = 69.dp)
-                    Second -> FlowerImage(image = R.drawable.img_home_second_stage_me, width = 77.dp, height = 117.dp)
-                    Third -> FlowerImage(image = R.drawable.img_home_third_stage_me, width = 102.dp, height = 179.dp)
-                    Fourth -> FlowerImage(image = image, width = 127.dp, height = 211.dp)
-                    Fifth -> FlowerImage(image = image, width = 127.dp, height = 211.dp)
+                    Zero -> FlowerImage(image = R.drawable.img_home_zero_stage_me, width = width, height = height)
+                    First -> FlowerImage(image = R.drawable.img_home_first_stage_me, width = width, height = height)
+                    Second -> FlowerImage(image = R.drawable.img_home_second_stage_me, width = width, height = height)
+                    Third -> FlowerImage(image = R.drawable.img_home_third_stage_me, width = width, height = height)
+                    Fourth -> FlowerImage(image = image, width = width, height = height)
+                    Fifth -> FlowerImage(image = image, width = width, height = height)
                 }
             }
             PARTNER -> {
                 val name = "img_home_${growType.name.lowercase()}_stage_${flowerName.name.lowercase()}_partner"
                 val image = context.resources.getIdentifier(name, "drawable", context.packageName)
+                val (width, height) = calculateWidthAndHeight(screenWidth, screenHeight, growType)
 
                 when (growType) {
-                    Zero -> FlowerImage(image = R.drawable.img_home_zero_stage_partner, width = 53.dp, height = 49.dp)
-                    First -> FlowerImage(image = R.drawable.img_home_first_stage_partner, width = 76.dp, height = 69.dp)
-                    Second -> FlowerImage(image = R.drawable.img_home_second_stage_partner, width = 77.dp, height = 117.dp)
-                    Third -> FlowerImage(image = R.drawable.img_home_third_stage_partner, width = 102.dp, height = 179.dp)
-                    Fourth -> FlowerImage(image = image, width = 127.dp, height = 211.dp)
-                    Fifth -> FlowerImage(image = image, width = 127.dp, height = 211.dp)
+                    Zero -> FlowerImage(image = R.drawable.img_home_zero_stage_partner, width = width, height = height)
+                    First -> FlowerImage(image = R.drawable.img_home_first_stage_partner, width = width, height = height)
+                    Second -> FlowerImage(image = R.drawable.img_home_second_stage_partner, width = width, height = height)
+                    Third -> FlowerImage(image = R.drawable.img_home_third_stage_partner, width = width, height = height)
+                    Fourth -> FlowerImage(image = image, width = width, height = height)
+                    Fifth -> FlowerImage(image = image, width = width, height = height)
                 }
             }
         }
@@ -68,5 +71,21 @@ data class Flower(
         val name = flowerName.name.lowercase()
         val flowerName = context.resources.getIdentifier(name, "string", context.packageName)
         return context.getString(flowerName)
+    }
+
+    private fun calculateWidthAndHeight(screenWidth: Int, screenHeight: Int, stage: Stage): Pair<Dp, Dp> {
+        return when (stage) {
+            Zero -> Pair((53 * screenWidth / figmaScreenWidth).dp, (49 * screenHeight / figmaScreenHeight).dp)
+            First -> Pair((76 * screenWidth / figmaScreenWidth).dp, (69 * screenHeight / figmaScreenHeight).dp)
+            Second -> Pair((77 * screenWidth / figmaScreenWidth).dp, (117 * screenHeight / figmaScreenHeight).dp)
+            Third -> Pair((102 * screenWidth / figmaScreenWidth).dp, (183 * screenHeight / figmaScreenHeight).dp)
+            Fourth -> Pair((127 * screenWidth / figmaScreenWidth).dp, (211 * screenHeight / figmaScreenHeight).dp)
+            Fifth -> Pair((127 * screenWidth / figmaScreenWidth).dp, (211 * screenHeight / figmaScreenHeight).dp)
+        }
+    }
+
+    companion object {
+        const val figmaScreenHeight = 812
+        const val figmaScreenWidth = 375
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/home/model/HomeCheerUiModel.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/home/model/HomeCheerUiModel.kt
@@ -63,7 +63,8 @@ data class CheerWithFlower(
 
         val partnerNotEmpty = CheerWithFlower(
             homeFlowerUiModel = HomeFlowerUiModel.partner,
-            cheerText = "파트너의 응원",
+            cheerText = "파트너의응원입니다.\n파트너의응원입니다",
+
         )
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/home/ongoing/HomeOngoingChallenge.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/home/ongoing/HomeOngoingChallenge.kt
@@ -78,7 +78,7 @@ fun HomeOngoingChallenge(
         TwoTooGoalAchievementProgressbar(
             modifier = Modifier.width(210.dp).height(59.dp).constrainAs(goalAchievement) {
                 start.linkTo(homeGoalField.start)
-                top.linkTo(homeGoalField.bottom)
+                top.linkTo(homeGoalField.bottom, margin = 11.dp)
             }.background(color = Color.White, shape = RoundedCornerShape(15.dp)),
             homeGoalAchievePartnerAndMeUiModel = ongoingChallengeUiModel.homeGoalAchievePartnerAndMeUiModel,
         )

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/home/ongoing/HomeOngoingChallenge.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/home/ongoing/HomeOngoingChallenge.kt
@@ -91,7 +91,7 @@ fun HomeOngoingChallenge(
             homeGoalCountUiModel = ongoingChallengeUiModel.homeGoalCountUiModel,
         )
 
-        val barrier = createTopBarrier(homeBackground, margin = 60.dp)
+        val barrier = createTopBarrier(homeBackground, margin = 80.dp)
         HomeFlowerMeAndPartner(
             modifier = Modifier.fillMaxWidth().constrainAs(homeFlower) {
                 start.linkTo(parent.start)

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/home/ongoing/components/HomeFlower.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/home/ongoing/components/HomeFlower.kt
@@ -191,7 +191,20 @@ fun HomeFlowerMeAndPartner(
                     modifier = Modifier.constrainAs(partnerCheer) {
                         start.linkTo(parent.start, margin = 32.dp)
                         end.linkTo(heartImage.start)
-                        bottom.linkTo(partner.top, margin = 12.dp)
+                        bottom.linkTo(
+                            partner.top,
+                            margin =
+                            if ((this@with.partner.homeFlowerUiModel.flowerType as Flower).growType >= Stage.Third) {
+                                0.dp
+                            } else {
+                                if (cheerState in listOf(CheerState.CheerOnlyMe, CheerState.DoNotCheerBoth)) {
+                                    18.dp
+                                } else {
+                                    12.dp
+                                }
+                            },
+
+                        )
                     },
                     cheerState = this.cheerState,
                     cheerText = this.partner.cheerText,
@@ -200,7 +213,7 @@ fun HomeFlowerMeAndPartner(
                     modifier = Modifier.constrainAs(partner) {
                         start.linkTo(partnerFlowerOwnerText.start)
                         end.linkTo(partnerFlowerOwnerText.end)
-                        bottom.linkTo(partnerFlowerOwnerText.top, margin = 3.dp)
+                        bottom.linkTo(partnerFlowerOwnerText.top, margin = 7.dp)
                     },
                     homeFlowerUiModel = this.partner.homeFlowerUiModel,
                 )
@@ -233,7 +246,19 @@ fun HomeFlowerMeAndPartner(
                             top.linkTo(parent.top)
                             start.linkTo(heartImage.end)
                             end.linkTo(parent.end, margin = 32.dp)
-                            bottom.linkTo(me.top, margin = 12.dp)
+                            bottom.linkTo(
+                                me.top,
+                                margin =
+                                if ((this@with.me.homeFlowerUiModel.flowerType as Flower).growType >= Stage.Third) {
+                                    0.dp
+                                } else {
+                                    if (cheerState in listOf(CheerState.CheerOnlyPartner, CheerState.DoNotCheerBoth)) {
+                                        32.dp
+                                    } else {
+                                        42.dp
+                                    }
+                                },
+                            )
                         },
                     cheerState = this.cheerState,
                     cheerText = this.me.cheerText,

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/home/ongoing/components/HomeFlower.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/home/ongoing/components/HomeFlower.kt
@@ -14,6 +14,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -328,7 +330,9 @@ fun HomeFlowerPartner(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    with(homeFlowerUiModel.flowerType.getFlowerImage(context = context)) {
+    val screenWidth = LocalConfiguration.current.screenWidthDp
+    val screenHeight = LocalConfiguration.current.screenHeightDp
+    with(homeFlowerUiModel.flowerType.getFlowerImage(context = context, screenWidth = screenWidth, screenHeight = screenHeight)) {
         TwoTooImageView(
             modifier = modifier
                 .testTag(
@@ -337,6 +341,7 @@ fun HomeFlowerPartner(
                 .width(width)
                 .height(height),
             model = image,
+            contentScale = ContentScale.Fit,
         )
     }
 }
@@ -347,7 +352,9 @@ fun HomeFlowerMe(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    with(homeFlowerUiModel.flowerType.getFlowerImage(context = context)) {
+    val screenWidth = LocalConfiguration.current.screenWidthDp
+    val screenHeight = LocalConfiguration.current.screenHeightDp
+    with(homeFlowerUiModel.flowerType.getFlowerImage(context = context, screenWidth = screenWidth, screenHeight = screenHeight)) {
         TwoTooImageView(
             modifier = modifier
                 .testTag(
@@ -356,6 +363,7 @@ fun HomeFlowerMe(
                 .width(width)
                 .height(height),
             model = image,
+            contentScale = ContentScale.Fit,
         )
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/home/ongoing/components/HomeGoalField.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/home/ongoing/components/HomeGoalField.kt
@@ -22,7 +22,7 @@ fun HomeGoalField(
     modifier: Modifier = Modifier,
 ) {
     ConstraintLayout(
-        modifier = modifier.padding(vertical = 16.dp).background(
+        modifier = modifier.background(
             color = TwoTooTheme.color.mainYellow,
             shape = TwoTooTheme.shape.small,
         ),

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/model/FlowerInfo.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/model/FlowerInfo.kt
@@ -39,7 +39,7 @@ fun String.toFlowerName(): FlowerName =
     FlowerName.findBy(this)
 
 abstract class FlowerType(val name: FlowerName) {
-    abstract fun getFlowerImage(context: Context): FlowerImage
+    abstract fun getFlowerImage(context: Context, screenWidth: Int, screenHeight: Int): FlowerImage
 }
 
 data class FlowerImage(


### PR DESCRIPTION
## 🔥 관련 이슈
x

## 🔥 PR Point
- 화면에서 짤리는 경우도 있어서, screen별로 꽃의 이미지의 크기를 조정하였습니다.
- mainToolBar 사이즈를 44로 변경하였습니다 ( 피그마 적용 ) 
- Home의 layout을 Constraintlayout -> Column으로 변경하였습니다

## 🔥 To Reviewers



## 📷 Screenshot
|기능|스크린샷|
|:---|---|
|기능A 구현|<img src = "" width = 400>|
|기능B 구현||
|...||
