### PR TITLE
Refactor/bottom sheet

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ image_cropper = "4.3.3"
 firebase-bom = "32.2.0"
 turbine = "1.0.0"
 coroutine_test = "1.7.2"
+bottomsheetdialog = "1.2.1"
 
 [libraries]
 core-ktx = { module = "androidx.core:core-ktx", version.ref = "core_ktx" }
@@ -111,6 +112,9 @@ image-cropper = { module = "com.vanniktech:android-image-cropper", version.ref =
 
 #turbine
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
+
+#bottomsheetdialog
+bottomsheetdialog = { module ="com.holix.android:bottomsheetdialog-compose", version.ref = "bottomsheetdialog" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android_gradle_plugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ firebase-bom = "32.2.0"
 turbine = "1.0.0"
 coroutine_test = "1.7.2"
 bottomsheetdialog = "1.2.1"
+extensions-compose-keyboard-state = "1.4.3"
 
 [libraries]
 core-ktx = { module = "androidx.core:core-ktx", version.ref = "core_ktx" }
@@ -115,6 +116,8 @@ turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 #bottomsheetdialog
 bottomsheetdialog = { module ="com.holix.android:bottomsheetdialog-compose", version.ref = "bottomsheetdialog" }
+
+compose-keyboard-state = { module = "tech.thdev:extensions-compose-keyboard-state", version.ref = "extensions-compose-keyboard-state" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android_gradle_plugin" }

--- a/presenter/build.gradle.kts
+++ b/presenter/build.gradle.kts
@@ -85,6 +85,7 @@ dependencies {
     testImplementation(libs.kotlin.coroutine.test)
     implementation(libs.accompanist.webview)
     implementation(libs.bottomsheetdialog)
+    implementation(libs.compose.keyboard.state)
 }
 
 fun getApiKey(propertyKey: String): String {

--- a/presenter/build.gradle.kts
+++ b/presenter/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
     testImplementation(libs.orbit.test)
     testImplementation(libs.kotlin.coroutine.test)
     implementation(libs.accompanist.webview)
+    implementation(libs.bottomsheetdialog)
 }
 
 fun getApiKey(propertyKey: String): String {

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/beforeChallenge/HomeBeforeChallengeTest.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/beforeChallenge/HomeBeforeChallengeTest.kt
@@ -30,6 +30,7 @@ class HomeBeforeChallengeTest {
             TwoTooTheme {
                 HomeScreen(
                     state = challengeStateTypeUiModel,
+                    navigateToGuide = {}
                 )
             }
         }
@@ -66,6 +67,7 @@ class HomeBeforeChallengeTest {
             TwoTooTheme {
                 HomeScreen(
                     state = challengeStateTypeUiModel,
+                    navigateToGuide = {}
                 )
             }
         }
@@ -99,6 +101,7 @@ class HomeBeforeChallengeTest {
             TwoTooTheme {
                 HomeScreen(
                     state = challengeStateTypeUiModel,
+                    navigateToGuide = {}
                 )
             }
         }
@@ -133,6 +136,7 @@ class HomeBeforeChallengeTest {
             TwoTooTheme {
                 HomeScreen(
                     state = challengeStateTypeUiModel,
+                    navigateToGuide = {}
                 )
             }
         }
@@ -172,6 +176,7 @@ class HomeBeforeChallengeTest {
             TwoTooTheme {
                 HomeScreen(
                     state = challengeStateTypeUiModel,
+                    navigateToGuide = {}
                 )
             }
         }

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/both/HomeOngoingBothAuthTest.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/both/HomeOngoingBothAuthTest.kt
@@ -130,6 +130,7 @@ class HomeOngoingBothAuthTest {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),
                     state = challengeStateTypeUiModel,
+                    navigateToGuide = {}
                 )
             }
         }

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/doNotBoth/HomeOngoingDoNotAuthBothTest.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/doNotBoth/HomeOngoingDoNotAuthBothTest.kt
@@ -131,6 +131,7 @@ class HomeOngoingDoNotAuthBothTest {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),
                     state = challengeStateTypeUiModel,
+                    navigateToGuide = {}
                 )
             }
         }

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/firstCreateChallenge/HomeOngoingFirstChallengeTest.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/firstCreateChallenge/HomeOngoingFirstChallengeTest.kt
@@ -51,6 +51,7 @@ class HomeOngoingFirstChallengeTest {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),
                     state = challengeStateTypeUiModel,
+                    navigateToGuide = {}
                 )
             }
         }
@@ -99,6 +100,7 @@ class HomeOngoingFirstChallengeTest {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),
                     state = challengeStateTypeUiModel,
+                    navigateToGuide = {}
                 )
             }
         }

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/onlyMe/HomeOngoingAuthOnlyMeTest.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/onlyMe/HomeOngoingAuthOnlyMeTest.kt
@@ -131,6 +131,7 @@ class HomeOngoingAuthOnlyMeTest {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),
                     state = challengeStateTypeUiModel,
+                    navigateToGuide = {}
                 )
             }
         }

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/onlyPartner/HomeOngoingAuthOnlyPartnerTest.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/auth/onlyPartner/HomeOngoingAuthOnlyPartnerTest.kt
@@ -131,6 +131,7 @@ class HomeOngoingAuthOnlyPartnerTest {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),
                     state = challengeStateTypeUiModel,
+                    navigateToGuide = {}
                 )
             }
         }

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/cheer/both/HomeCheerBothTest.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/cheer/both/HomeCheerBothTest.kt
@@ -157,6 +157,7 @@ class HomeCheerBothTest {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),
                     state = challengeStateTypeUiModel,
+                    navigateToGuide = {}
                 )
             }
         }

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/cheer/doNotBoth/HomeCheerDoNotBothTest.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/cheer/doNotBoth/HomeCheerDoNotBothTest.kt
@@ -158,6 +158,7 @@ class HomeCheerDoNotBothTest {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),
                     state = challengeStateTypeUiModel,
+                    navigateToGuide = {}
                 )
             }
         }

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/cheer/onlyMe/HomeCheerOnlyMeTest.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/cheer/onlyMe/HomeCheerOnlyMeTest.kt
@@ -159,6 +159,7 @@ class HomeCheerOnlyMeTest {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),
                     state = challengeStateTypeUiModel,
+                    navigateToGuide = {}
                 )
             }
         }

--- a/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/cheer/onlyPartner/HomeCheerOnlyPartner.kt
+++ b/presenter/src/androidTest/java/com/mashup/twotoo/presenter/home/ongoingChallenge/cheer/onlyPartner/HomeCheerOnlyPartner.kt
@@ -158,6 +158,7 @@ class HomeCheerOnlyPartner {
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),
                     state = challengeStateTypeUiModel,
+                    navigateToGuide = {}
                 )
             }
         }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/bottomsheet/Authenticate.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/bottomsheet/Authenticate.kt
@@ -20,8 +20,6 @@ import com.mashup.twotoo.presenter.designsystem.component.bottomsheet.BottomShee
 import com.mashup.twotoo.presenter.designsystem.component.button.TwoTooTextButton
 import com.mashup.twotoo.presenter.designsystem.component.textfield.TwoTooTextField
 import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
-import com.mashup.twotoo.presenter.util.addFocusCleaner
-import com.mashup.twotoo.presenter.util.keyboardAsState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -35,17 +33,11 @@ fun AuthenticateContent(
 ) {
     var animateSwitch by remember { mutableStateOf(false) }
     val focusManager = LocalFocusManager.current
-    val keyBoardOpenState by keyboardAsState()
     val coroutineScope = rememberCoroutineScope()
-    LaunchedEffect(keyBoardOpenState) {
-        if (!keyBoardOpenState) {
-            animateSwitch = false
-            focusManager.clearFocus()
-        }
-    }
+
     Column(
         modifier = modifier
-            .fillMaxWidth().fillMaxHeight(0.8f).addFocusCleaner(focusManager).padding(horizontal = 20.dp),
+            .fillMaxWidth().fillMaxHeight(0.76f).padding(horizontal = 20.dp),
         verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/bottomsheet/Authenticate.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/bottomsheet/Authenticate.kt
@@ -30,6 +30,7 @@ fun AuthenticateContent(
     type: Authenticate,
     onClickPlusButton: () -> Unit,
     onClickButton: (BottomSheetData) -> Unit,
+    modifier: Modifier = Modifier,
     imageUri: Uri? = null,
 ) {
     var animateSwitch by remember { mutableStateOf(false) }
@@ -43,11 +44,12 @@ fun AuthenticateContent(
         }
     }
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth().fillMaxHeight(0.8f).addFocusCleaner(focusManager).padding(horizontal = 20.dp),
-        verticalArrangement = Arrangement.SpaceAround,
+        verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        Spacer(modifier = Modifier.height(46.dp))
         Header(
             titleText = stringResource(id = type.title),
         )
@@ -57,25 +59,29 @@ fun AuthenticateContent(
                 targetHeight = { 0 },
             ),
         ) {
-            TwoTooImageViewWithSetter(
-                modifier = Modifier
-                    .aspectRatio(1f)
-                    .clip(
-                        TwoTooTheme.shape.extraSmall,
-                    ),
-                imageUri = { imageUri ?: R.drawable.empty_image_color_placeholder },
-                onClickPlusButton = {
-                    onClickPlusButton()
-                },
-                previewPlaceholder = R.drawable.empty_image_color_placeholder,
-                failurePlaceHolder = {},
-                loadingPlaceHolder = {},
-            )
+            Column {
+                Spacer(modifier = Modifier.height(16.dp))
+                TwoTooImageViewWithSetter(
+                    modifier = Modifier
+                        .aspectRatio(1f)
+                        .clip(
+                            TwoTooTheme.shape.extraSmall,
+                        ),
+                    imageUri = { imageUri ?: R.drawable.empty_image_color_placeholder },
+                    onClickPlusButton = {
+                        onClickPlusButton()
+                    },
+                    previewPlaceholder = R.drawable.empty_image_color_placeholder,
+                    failurePlaceHolder = {},
+                    loadingPlaceHolder = {},
+                )
+            }
         }
 
         var textFieldState by rememberSaveable {
             mutableStateOf("")
         }
+        Spacer(modifier = Modifier.height(16.dp))
         TextWrapper(
             modifier = Modifier
                 .fillMaxWidth().height(85.dp),
@@ -90,6 +96,7 @@ fun AuthenticateContent(
                 }
             },
         )
+        Spacer(modifier = Modifier.height(29.dp))
         TwoTooTextButton(
             modifier = Modifier
                 .fillMaxWidth().height(57.dp),

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/bottomsheet/BottomSheet.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/bottomsheet/BottomSheet.kt
@@ -154,7 +154,7 @@ fun TwoTooAuthBottomSheet(
                 },
                 onClickButton = onClickButton,
                 modifier = Modifier.removeFocusWhenKeyboardIsHidden().background(
-                    color = Color(0xFFFCF5E6),
+                    color = TwoTooTheme.color.backgroundYellow,
                     shape = RoundedCornerShape(topStart = 60f, topEnd = 60f),
                 ),
             )
@@ -185,7 +185,7 @@ fun TwoTooSendMsgBottomSheet(
     ) {
         SendMsgBottomSheetContent(
             modifier = Modifier.removeFocusWhenKeyboardIsHidden().background(
-                color = Color(0xFFFCF5E6),
+                color = TwoTooTheme.color.backgroundYellow,
                 shape = RoundedCornerShape(topStart = 60f, topEnd = 60f),
             ),
             type = type,

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/bottomsheet/BottomSheet.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/bottomsheet/BottomSheet.kt
@@ -7,20 +7,22 @@ import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import com.canhub.cropper.CropImageContract
 import com.canhub.cropper.CropImageContractOptions
 import com.canhub.cropper.CropImageOptions
+import com.holix.android.bottomsheetdialog.compose.BottomSheetDialog
 import com.mashup.twotoo.presenter.designsystem.component.bottomsheet.BottomSheetType.Authenticate
 import com.mashup.twotoo.presenter.designsystem.component.bottomsheet.BottomSheetType.SendType
 import com.mashup.twotoo.presenter.designsystem.component.bottomsheet.BottomSheetType.SendType.Cheer
@@ -30,12 +32,10 @@ import kotlinx.coroutines.launch
 import java.io.File
 import java.util.Objects
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TwoTooBottomSheet(
     type: BottomSheetType,
     onDismiss: () -> Unit,
-    bottomSheetState: SheetState = rememberModalBottomSheetState(),
     onClickButton: (BottomSheetData) -> Unit = {},
 ) {
     when (type) {
@@ -43,25 +43,21 @@ fun TwoTooBottomSheet(
             type = type,
             onClickButton = onClickButton,
             onDismiss = onDismiss,
-            bottomSheetState = bottomSheetState,
         )
 
         is SendType -> TwoTooSendMsgBottomSheet(
             type = type,
             onClickButton = onClickButton,
             onDismiss = onDismiss,
-            bottomSheetState = bottomSheetState,
         )
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TwoTooAuthBottomSheet(
     type: Authenticate,
     onClickButton: (BottomSheetData) -> Unit,
     onDismiss: () -> Unit,
-    bottomSheetState: SheetState,
 ) {
     var imageUri by remember {
         mutableStateOf<Uri?>(null)
@@ -136,7 +132,6 @@ fun TwoTooAuthBottomSheet(
 
     Box(modifier = Modifier.fillMaxSize()) {
         TwoTooBottomSheetImpl(
-            bottomSheetState = bottomSheetState,
             onDismiss = onDismiss,
         ) {
             AuthenticateContent(
@@ -153,6 +148,10 @@ fun TwoTooAuthBottomSheet(
                     }
                 },
                 onClickButton = onClickButton,
+                modifier = Modifier.background(
+                    color = Color(0xFFFCF5E6),
+                    shape = RoundedCornerShape(topStart = 60f, topEnd = 60f),
+                ),
             )
         }
         if (setImageDialogVisible) {
@@ -170,54 +169,36 @@ fun TwoTooAuthBottomSheet(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TwoTooSendMsgBottomSheet(
     type: SendType,
     onDismiss: () -> Unit,
-    bottomSheetState: SheetState = rememberModalBottomSheetState(),
     onClickButton: (BottomSheetData) -> Unit = {},
 ) {
-    val focusManager = LocalFocusManager.current
     TwoTooBottomSheetImpl(
-        bottomSheetState = bottomSheetState,
-        onDismiss = {
-            focusManager.clearFocus()
-            onDismiss()
-        },
+        onDismiss = onDismiss,
     ) {
         SendMsgBottomSheetContent(
+            modifier = Modifier.background(
+                color = Color(0xFFFCF5E6),
+                shape = RoundedCornerShape(topStart = 60f, topEnd = 60f),
+            ),
             type = type,
             onClickButton = onClickButton,
-            focusManager = focusManager,
         )
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TwoTooBottomSheetImpl(
-    bottomSheetState: SheetState,
     onDismiss: () -> Unit,
     bottomSheetContent: @Composable () -> Unit,
 ) {
-    ModalBottomSheet(
-        sheetState = bottomSheetState,
+    BottomSheetDialog(
         onDismissRequest = onDismiss,
-        containerColor = Color(0xFFFCF5E6),
     ) {
         bottomSheetContent()
     }
-}
-
-@Composable
-fun TestButton(
-    modifier: Modifier = Modifier,
-) {
-    Text(
-        modifier = modifier,
-        text = "버튼입니다.",
-    )
 }
 
 /**
@@ -245,7 +226,6 @@ fun OpenAuthenticate() {
             }
             if (isBottomSheetVisible) {
                 TwoTooBottomSheet(
-                    bottomSheetState = bottomSheetState,
                     type = Authenticate(),
                     onDismiss = {
                         coroutineScope.launch {
@@ -285,7 +265,6 @@ private fun OpenShot() {
             }
             if (isBottomSheetVisible) {
                 TwoTooBottomSheet(
-                    bottomSheetState = bottomSheetState,
                     type = Shot(),
                     onDismiss = {
                         coroutineScope.launch {
@@ -322,7 +301,6 @@ private fun OpenCheer() {
             }
             if (isBottomSheetVisible) {
                 TwoTooBottomSheet(
-                    bottomSheetState = bottomSheetState,
                     type = Cheer(),
                     onDismiss = {
                         coroutineScope.launch {

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/bottomsheet/BottomSheet.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/bottomsheet/BottomSheet.kt
@@ -22,13 +22,18 @@ import androidx.core.content.FileProvider
 import com.canhub.cropper.CropImageContract
 import com.canhub.cropper.CropImageContractOptions
 import com.canhub.cropper.CropImageOptions
+import com.holix.android.bottomsheetdialog.compose.BottomSheetBehaviorProperties
 import com.holix.android.bottomsheetdialog.compose.BottomSheetDialog
+import com.holix.android.bottomsheetdialog.compose.BottomSheetDialogProperties
 import com.mashup.twotoo.presenter.designsystem.component.bottomsheet.BottomSheetType.Authenticate
 import com.mashup.twotoo.presenter.designsystem.component.bottomsheet.BottomSheetType.SendType
 import com.mashup.twotoo.presenter.designsystem.component.bottomsheet.BottomSheetType.SendType.Cheer
 import com.mashup.twotoo.presenter.designsystem.component.bottomsheet.BottomSheetType.SendType.Shot
 import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
 import kotlinx.coroutines.launch
+import tech.thdev.compose.extensions.keyboard.state.MutableExKeyboardStateSource
+import tech.thdev.compose.extensions.keyboard.state.foundation.removeFocusWhenKeyboardIsHidden
+import tech.thdev.compose.extensions.keyboard.state.localowners.LocalMutableExKeyboardStateSourceOwner
 import java.io.File
 import java.util.Objects
 
@@ -148,7 +153,7 @@ fun TwoTooAuthBottomSheet(
                     }
                 },
                 onClickButton = onClickButton,
-                modifier = Modifier.background(
+                modifier = Modifier.removeFocusWhenKeyboardIsHidden().background(
                     color = Color(0xFFFCF5E6),
                     shape = RoundedCornerShape(topStart = 60f, topEnd = 60f),
                 ),
@@ -179,7 +184,7 @@ fun TwoTooSendMsgBottomSheet(
         onDismiss = onDismiss,
     ) {
         SendMsgBottomSheetContent(
-            modifier = Modifier.background(
+            modifier = Modifier.removeFocusWhenKeyboardIsHidden().background(
                 color = Color(0xFFFCF5E6),
                 shape = RoundedCornerShape(topStart = 60f, topEnd = 60f),
             ),
@@ -196,8 +201,17 @@ fun TwoTooBottomSheetImpl(
 ) {
     BottomSheetDialog(
         onDismissRequest = onDismiss,
+        properties = BottomSheetDialogProperties(
+            behaviorProperties = BottomSheetBehaviorProperties(
+                state = BottomSheetBehaviorProperties.State.Expanded,
+            ),
+        ),
     ) {
-        bottomSheetContent()
+        CompositionLocalProvider(
+            LocalMutableExKeyboardStateSourceOwner provides MutableExKeyboardStateSource(),
+        ) {
+            bottomSheetContent()
+        }
     }
 }
 

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/bottomsheet/ShotAndCheer.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/bottomsheet/ShotAndCheer.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalView
@@ -22,13 +21,11 @@ import com.mashup.twotoo.presenter.designsystem.component.bottomsheet.BottomShee
 import com.mashup.twotoo.presenter.designsystem.component.button.TwoTooTextButton
 import com.mashup.twotoo.presenter.designsystem.component.textfield.TwoTooTextField
 import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
-import com.mashup.twotoo.presenter.util.addFocusCleaner
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @Composable
 fun SendMsgBottomSheetContent(
-    focusManager: FocusManager,
     type: SendType,
     modifier: Modifier = Modifier,
     onClickButton: (BottomSheetData) -> Unit = {},
@@ -40,23 +37,22 @@ fun SendMsgBottomSheetContent(
         mutableStateOf("")
     }
 
-//    val focusManager = LocalFocusManager.current
     val focusRequester = remember { FocusRequester() }
     val coroutineScope = rememberCoroutineScope()
+    val focusManager = LocalFocusManager.current
 
     LocalView.current.viewTreeObserver.addOnWindowFocusChangeListener { isFocusable ->
         if (isFocusable) {
-            coroutineScope.launch {
-                delay(250)
-                focusRequester.requestFocus()
-            }
+            focusRequester.requestFocus()
         }
     }
+
     Column(
-        modifier = modifier.fillMaxWidth().addFocusCleaner(focusManager).imePadding().padding(horizontal = 20.dp),
-        verticalArrangement = Arrangement.SpaceBetween,
+        modifier = modifier.fillMaxWidth().fillMaxHeight(0.85f).padding(horizontal = 20.dp),
+        verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        Spacer(modifier = Modifier.height(46.dp))
         Header(titleText = titleText)
         Spacer(modifier = Modifier.height(20.5.dp))
         TwoTooTextField(
@@ -101,10 +97,8 @@ fun SendMsgBottomSheetContent(
 @Composable
 private fun PreviewShotList() {
     TwoTooTheme {
-        val focusManager = LocalFocusManager.current
         SendMsgBottomSheetContent(
             type = Shot(),
-            focusManager = focusManager,
         )
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/bottomsheet/ShotAndCheer.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/bottomsheet/ShotAndCheer.kt
@@ -1,5 +1,6 @@
 package com.mashup.twotoo.presenter.designsystem.component.bottomsheet
 
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
@@ -7,6 +8,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
@@ -23,6 +25,8 @@ import com.mashup.twotoo.presenter.designsystem.component.textfield.TwoTooTextFi
 import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import tech.thdev.compose.extensions.keyboard.state.foundation.collectIsKeyboardAsState
+import tech.thdev.compose.extensions.keyboard.state.localowners.LocalMutableExKeyboardStateSourceOwner
 
 @Composable
 fun SendMsgBottomSheetContent(
@@ -46,9 +50,24 @@ fun SendMsgBottomSheetContent(
             focusRequester.requestFocus()
         }
     }
+    val keyboardState by LocalMutableExKeyboardStateSourceOwner.current.collectIsKeyboardAsState()
+
+    val screenHeight = LocalConfiguration.current.screenHeightDp
+    var isCreated by remember { mutableStateOf(true) }
+
+    val animateHeight = remember { Animatable(screenHeight * 0.76f) }
+
+    LaunchedEffect(keyboardState) {
+        if (!keyboardState && !isCreated) {
+            animateHeight.animateTo(screenHeight * 0.35f)
+        } else {
+            animateHeight.animateTo(screenHeight * 0.76f)
+            isCreated = false
+        }
+    }
 
     Column(
-        modifier = modifier.fillMaxWidth().fillMaxHeight(0.85f).padding(horizontal = 20.dp),
+        modifier = modifier.fillMaxWidth().height(animateHeight.value.dp).padding(horizontal = 20.dp),
         verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/home/Home.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/home/Home.kt
@@ -34,9 +34,6 @@ import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
-@OptIn(
-    ExperimentalMaterial3Api::class,
-)
 @Composable
 fun HomeRoute(
     homeViewModel: HomeViewModel,

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/home/Home.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/home/Home.kt
@@ -91,7 +91,6 @@ fun HomeRoute(
         with(homeSideEffectHandler) {
             if (isBottomSheetVisible) {
                 TwoTooBottomSheet(
-                    bottomSheetState = bottomSheetState,
                     type = bottomSheetType,
                     onDismiss = ::onDismiss,
                     onClickButton = homeViewModel::onClickSendBottomSheetDataButton,

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/home/HomeSideEffectHandler.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/home/HomeSideEffectHandler.kt
@@ -2,9 +2,6 @@ package com.mashup.twotoo.presenter.home
 
 import android.content.Context
 import androidx.compose.material.SnackbarHostState
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.SheetState
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
@@ -22,11 +19,9 @@ import com.mashup.twotoo.presenter.home.model.ToastText
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun rememberHomeSideEffectHandler(
     context: Context = LocalContext.current,
-    bottomSheetState: SheetState = rememberModalBottomSheetState(true),
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     coroutineScope: CoroutineScope = rememberCoroutineScope(),
     navigateToHistory: (Int) -> Unit,
@@ -42,13 +37,11 @@ fun rememberHomeSideEffectHandler(
 ): HomeSideEffectHandler {
     return remember(
         context,
-        bottomSheetState,
         snackbarHostState,
         coroutineScope,
     ) {
         HomeSideEffectHandler(
             context = context,
-            bottomSheetState = bottomSheetState,
             snackbarHostState = snackbarHostState,
             coroutineScope = coroutineScope,
             navigateToHistory = navigateToHistory,
@@ -66,10 +59,8 @@ fun rememberHomeSideEffectHandler(
 }
 
 @Stable
-@OptIn(ExperimentalMaterial3Api::class)
 class HomeSideEffectHandler(
     val context: Context,
-    val bottomSheetState: SheetState,
     val snackbarHostState: SnackbarHostState,
     val coroutineScope: CoroutineScope,
     private val navigateToHistory: (Int) -> Unit,


### PR DESCRIPTION
## 🔥 관련 이슈
x

## 🔥 PR Point
-기존의 바텀시트에서 키보드 상태를 제어하기가 힘든 문제 해결
- imepadding을 적용시 바텀 시트가 총알같이 튀어나오는 문제 발생 
- imepadding이 없을 경우 하단 버튼이 키보드에 가리게 되지만, 이는 텍스트 필드에 집중하기 위해서 의도된 동작임
- 결국에 imepadding없이 bottom sheet의 높이를 조정하는 방안으로 변경

## 🔥 To Reviewers
진짜 여러 bottomsheet 라이브러리를 써봤는데 다 하나씩 아쉽네요
기존의 modalbottom sheet는 키보드 제어 말고는 괜찮았던거같은데, 다른 라이브러리를 쓰자니 키보드와 imepadding에서 문제가 발생했어요
modalbottomsheet의 크기를 최대한 크게 유지하면서 키보드를 띄워 imepadding적용없이 변경해보았습니다..ㅠ

modalbottomsheet는 버그가 너무 많아서 힘드네요
https://issuetracker.google.com/issues/258744762

하단 pr에 이어 브렌치를 파서  [00f3d46](https://github.com/mash-up-kr/TwoToo_Android/pull/181/commits/00f3d465c2544b3aa74ff265fa0dec9f7b7f4ae4) 여기서부터 보시면 됩니다


keyboardState를 얻는 library는 이것을 사용했습니다
https://github.com/taehwandev/ComposeKeyboardState


## 📷 Screenshot
|기능|스크린샷|
|:---|---|
|기능A 구현|https://github.com/mash-up-kr/TwoToo_Android/assets/62296097/effed1f2-ac9a-47e4-b566-326d56d6455f|
|...||
