### PR TITLE
[feat] : 바텀 네비게이션 바 색상 고정

### DIFF
--- a/presenter/src/main/java/com/mashup/twotoo/presenter/ui/TwoTooApp.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/ui/TwoTooApp.kt
@@ -46,8 +46,8 @@ fun TwoTooApp(
                     destinations = appState.topLevelDestinations,
                     onNavigateToDestination = appState::navigationToTopLevelDestination,
                     currentDestination = appState.currentDestination,
-                    containerColor = appState.getContainerColorByDestination,
-                    unSelectedColor = appState.getUnSelectedColorByDestination,
+                    containerColor = TwoTooTheme.color.mainPink,
+                    unSelectedColor = TwoTooTheme.color.backgroundYellow,
                 )
             }
         },

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/ui/TwoTooAppState.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/ui/TwoTooAppState.kt
@@ -3,14 +3,11 @@ package com.mashup.twotoo.presenter.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.graphics.Color
 import androidx.navigation.NavDestination
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
-import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
 import com.mashup.twotoo.presenter.garden.navigation.navigateToGarden
 import com.mashup.twotoo.presenter.home.navigation.navigateToHome
 import com.mashup.twotoo.presenter.mypage.navigation.navigateToUser
@@ -44,19 +41,6 @@ class TwoTooAppState(
 
     val topLevelDestinations: List<TopLevelDestination> = TopLevelDestination.values().asList()
 
-    val getContainerColorByDestination: Color
-        @Composable get() = if (currentTopLevelDestination == Home) {
-            TwoTooTheme.color.mainPink
-        } else {
-            TwoTooTheme.color.backgroundYellow
-        }
-
-    val getUnSelectedColorByDestination: Color
-        @Composable get() = if (currentTopLevelDestination == Home) {
-            TwoTooTheme.color.backgroundYellow
-        } else {
-            TwoTooTheme.color.mainPink
-        }
     fun navigationToTopLevelDestination(topLevelDestination: TopLevelDestination) {
         val topLevelOptions = navOptions {
             popUpTo(navController.graph.id) {


### PR DESCRIPTION
## 🔥 관련 이슈
x
## 🔥 PR Point

## 🔥 To Reviewers



## 📷 Screenshot
|기능|스크린샷|
|:---|---|
|바텀 네비게이션 색상 고정|https://github.com/mash-up-kr/TwoToo_Android/assets/62296097/ea3a8d74-8763-4214-b3a2-94b93c4f3b60|
