### PR TITLE
notification permission 추가 및 카카오 로그인 ID 획득

### DIFF
--- a/presenter/src/main/java/com/mashup/twotoo/presenter/MainActivity.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/MainActivity.kt
@@ -1,10 +1,19 @@
 package com.mashup.twotoo.presenter
 
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
@@ -19,13 +28,32 @@ class MainActivity : ComponentActivity() {
         setContent {
             TwoTooTheme {
                 val systemUiController = rememberSystemUiController()
+                val context = LocalContext.current
+                val launcher = rememberLauncherForActivityResult(
+                    ActivityResultContracts.RequestPermission(),
+                ) {}
                 SideEffect {
                     // set transparent color so that our image is visible
                     // behind the status bar
                     systemUiController.setStatusBarColor(color = Color.Transparent, darkIcons = true)
+                    checkPermission(context, launcher)
                 }
+
                 TwoTooApp()
             }
+        }
+    }
+}
+
+private fun checkPermission(context: Context, launcher: ManagedActivityResultLauncher<String, Boolean>) {
+    if (ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
+    ) {
+    } else {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            launcher.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/onboarding/OnBoardingViewModel.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/onboarding/OnBoardingViewModel.kt
@@ -50,8 +50,8 @@ class OnBoardingViewModel @Inject constructor(
         val user = fetchUserInfoAsync()
         intent {
             reduce {
-                Log.d(TAG, "updateLoginState: socialId${user?.kakaoAccount?.email}")
-                state.copy(isSuccessLogin = isSuccess, deviceToken = deviceToken, socialId = user?.kakaoAccount?.email ?: "")
+                Log.d(TAG, "updateLoginState: socialId${user?.id}")
+                state.copy(isSuccessLogin = isSuccess, deviceToken = deviceToken, socialId = user?.id.toString() ?: "")
             }
         }
     }


### PR DESCRIPTION
## 🔥 관련 이슈

close #204 

## 🔥 PR Point
- 노티 권한 추가
- 카카오 로그인 ID 획득

## 🔥 To Reviewers
<img width="764" alt="스크린샷 2023-07-31 오후 9 59 38" src="https://github.com/mash-up-kr/TwoToo_Android/assets/53086454/9a28e2bf-7d06-4dbe-89eb-7fe0cd77033b">

메인 최초 진입 시 알림 권한 받도록 추가했고 해당 권한 팝업은 Android13이상 부터 노출됩니다! 
(그 전 API는 디폴트가 허용이래요!) 안드 시스템 정책에 따라 두번 허용 하지 않으면 그 이후부터 안떠요!

카카오 로그인 로직이 간단하게 수정돼서 같이 올려요~!
기존에 email 받아왔던거 Id로 받아오도록 수정했어요!
(카카오 디벨로퍼에서도 설정 수정할게요)


## 📷 Screenshot
|기능|스크린샷|
|:---|---|
|기능A 구현|https://github.com/mash-up-kr/TwoToo_Android/assets/53086454/c6ebaeeb-68c7-4e51-81ea-48e7ef39db91

|

