### PR TITLE
다이얼로그 높이 수정 및 히스토리 카드 shape 변경

### DIFF
--- a/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/bottomsheet/ShotAndCheer.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/bottomsheet/ShotAndCheer.kt
@@ -23,6 +23,7 @@ import com.mashup.twotoo.presenter.designsystem.component.bottomsheet.BottomShee
 import com.mashup.twotoo.presenter.designsystem.component.button.TwoTooTextButton
 import com.mashup.twotoo.presenter.designsystem.component.textfield.TwoTooTextField
 import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
+import com.mashup.twotoo.presenter.util.DevicePreview
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import tech.thdev.compose.extensions.keyboard.state.foundation.collectIsKeyboardAsState
@@ -59,7 +60,7 @@ fun SendMsgBottomSheetContent(
 
     LaunchedEffect(keyboardState) {
         if (!keyboardState && !isCreated) {
-            animateHeight.animateTo(screenHeight * 0.35f)
+            animateHeight.animateTo(screenHeight * 0.40f)
         } else {
             animateHeight.animateTo(screenHeight * 0.76f)
             isCreated = false
@@ -119,5 +120,13 @@ private fun PreviewShotList() {
         SendMsgBottomSheetContent(
             type = Shot(),
         )
+    }
+}
+
+@DevicePreview
+@Composable
+private fun PreviewCheer() {
+    TwoTooTheme {
+        SendMsgBottomSheetContent(type = Cheer())
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/garden/GardenComponents.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/garden/GardenComponents.kt
@@ -3,7 +3,6 @@ package com.mashup.twotoo.presenter.garden
 import android.util.Log
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -31,7 +30,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mashup.twotoo.presenter.R
 import com.mashup.twotoo.presenter.designsystem.component.TwoTooImageView
-import com.mashup.twotoo.presenter.designsystem.theme.TwoTooRound6
+import com.mashup.twotoo.presenter.designsystem.theme.TwoTooRound10
 import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
 import com.mashup.twotoo.presenter.garden.model.ChallengeCardInfoUiModel
 import com.mashup.twotoo.presenter.garden.model.FlowerHead
@@ -65,11 +64,10 @@ fun ChallengeCard(
     Box(
         modifier = Modifier
             .graphicsLayer(translationY = offsetY.value)
-            .border(2.dp, borderColor, RoundedCornerShape(8.dp))
             .height(216.dp)
             .width(156.dp)
-            .clip(TwoTooRound6)
-            .background(TwoTooTheme.color.mainWhite)
+            .background(TwoTooTheme.color.mainWhite, TwoTooRound10)
+            .clip(TwoTooRound10)
             .clickable {
                 navigateToGarden(challengeCardInfoUiModel.challengeNo)
             },


### PR DESCRIPTION
## 🔥 관련 이슈
x

## 🔥 PR Point
다이얼로그 높이 수정하기 1080 2220에서도 대응하도록 함


## 🔥 To Reviewers



## 📷 Screenshot
|기능|스크린샷|
|:---|---|
|키보드 열렸을 때 |<img width="301" alt="스크린샷 2023-08-05 오후 3 24 23" src="https://github.com/mash-up-kr/TwoToo_Android/assets/62296097/14e5011e-c183-4380-8f48-9ce9f8b89c3b">|
|키보드 닫혔을 때 |<img width="301" alt="스크린샷 2023-08-05 오후 3 24 28" src="https://github.com/mash-up-kr/TwoToo_Android/assets/62296097/819829e8-388d-4766-bdb6-8d0177dffdc6">|
|...||

