### PR TITLE
챌린지 삭제 기능 추가 및 상태 리팩토링

### DIFF
--- a/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/CreatChallengeCard.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/CreatChallengeCard.kt
@@ -41,7 +41,7 @@ fun CreateChallengeCard(
     challengeDate: String,
     challengeDesc: String,
     isNextButtonVisible: Boolean = true,
-    onClickNext: () -> Unit
+    onClickNext: () -> Unit,
 ) {
     var width by remember { mutableIntStateOf(0) }
     Column(
@@ -123,7 +123,7 @@ fun ChallengeCardInfoTop(
 
 @Composable
 fun ChallengeCardInfoBottom(
-    modifier: Modifier
+    modifier: Modifier,
 ) {
     Text(
         modifier = modifier.then(

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/CreateChallengeSideEffect.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/CreateChallengeSideEffect.kt
@@ -4,4 +4,5 @@ sealed class CreateChallengeSideEffect {
     object NavigateToSuccessCreate : CreateChallengeSideEffect()
     object NavigateToHome : CreateChallengeSideEffect()
     data class ToastMessage(val message: String) : CreateChallengeSideEffect()
+    object DismissDialog : CreateChallengeSideEffect()
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/di/CreateChallengeModule.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/di/CreateChallengeModule.kt
@@ -5,6 +5,7 @@ import dagger.Module
 import dagger.Provides
 import usecase.challenge.ApproveChallengeUseCase
 import usecase.challenge.CreateChallengeUseCase
+import usecase.challenge.QuiteChallengeUseCase
 import javax.inject.Scope
 
 @Module
@@ -14,11 +15,13 @@ class CreateChallengeModule {
     @CreateChallengeScope
     fun provideViewModel(
         approveChallengeUseCase: ApproveChallengeUseCase,
-        createChallengeUseCase: CreateChallengeUseCase
+        createChallengeUseCase: CreateChallengeUseCase,
+        quiteChallengeUseCase: QuiteChallengeUseCase,
     ): CreateChallengeViewModel {
         return CreateChallengeViewModel(
             approveChallengeUseCase,
             createChallengeUseCase,
+            quiteChallengeUseCase,
         )
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/model/ChallengeInfoModel.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/model/ChallengeInfoModel.kt
@@ -1,17 +1,21 @@
 package com.mashup.twotoo.presenter.createChallenge.model
 
+import com.mashup.twotoo.presenter.home.model.BeforeChallengeState
 import com.mashup.twotoo.presenter.util.DateFormatter
 import model.challenge.request.CreateChallengeRequestDomainModel
 
 data class ChallengeInfoModel(
-    var currentStep: Int = 1,
-    var isBack: Boolean = false,
-    var challengeName: String = "",
-    var startDate: String = DateFormatter.getCurrentDate(),
+    val challengeNo: Int = 0,
+    val homeState: String = BeforeChallengeState.EMPTY.name,
+    val currentStep: Int = 1,
+    val isBack: Boolean = false,
+    val challengeName: String = "",
+    val startDate: String = DateFormatter.getCurrentDate(),
     val endDate: String = DateFormatter.getDaysAfter(DateFormatter.getCurrentDate()),
     val period: String = "",
-    var challengeInfo: String = "",
+    val challengeInfo: String = "",
     val selectFlowerName: String = "",
+    val dialogVisibility: Boolean = false,
 )
 
 fun ChallengeInfoModel.toDomainModel(): CreateChallengeRequestDomainModel {

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/navigation/CreateChallengeNavigation.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/navigation/CreateChallengeNavigation.kt
@@ -1,6 +1,8 @@
 package com.mashup.twotoo.presenter.createChallenge.navigation
 
 import android.annotation.SuppressLint
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.navigation.NavController
@@ -57,6 +59,11 @@ fun NavGraphBuilder.createChallengeGraph(
             val createChallengeViewModel = daggerViewModel {
                 challengeComponent.getViewModel()
             }
+
+            LaunchedEffect(homeState) {
+                createChallengeViewModel.setHomeState(homeState = homeState)
+                createChallengeViewModel.initChallengeStep(challengeInfo)
+            }
             val navOptions = navOptions {
                 popUpTo(navController.graph.startDestinationId) {
                     inclusive = true
@@ -64,8 +71,6 @@ fun NavGraphBuilder.createChallengeGraph(
             }
 
             CreateChallengeRoute(
-                homeState = homeState,
-                challengeInfo = challengeInfo,
                 createChallengeViewModel = createChallengeViewModel,
                 onBackToHome = { navController.popBackStack() },
                 onFinishChallengeInfo = {

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/selectflower/SelectFlowerCard.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/createChallenge/selectflower/SelectFlowerCard.kt
@@ -46,7 +46,7 @@ fun SelectFlowerCardRoute(
         onStartButtonClick = { flowerName ->
             when (homeState) {
                 BeforeChallengeState.EMPTY.name, BeforeChallengeState.TERMINATION.name -> {
-                    createChallengeViewModel.setCreateChallengeInfo(ChallengeInfoModel(selectFlowerName = flowerName), 4)
+                    createChallengeViewModel.setCreateChallengeInfo(ChallengeInfoModel(selectFlowerName = flowerName))
                     createChallengeViewModel.createChallenge()
                 }
                 BeforeChallengeState.RESPONSE.name -> {
@@ -75,7 +75,7 @@ fun SelectFlowerCardRoute(
 @Composable
 fun SelectFlowerCard(
     onStartButtonClick: (String) -> Unit = {},
-    onClickBackButton: () -> Unit = {}
+    onClickBackButton: () -> Unit = {},
 ) {
     var isVisibleStartButton by remember { mutableStateOf(false) }
     var flowerName by remember { mutableStateOf("") }


### PR DESCRIPTION
## 🔥 관련 이슈
x

## 🔥 PR Point
- viewModelState에 상태 추가 ( dialog, challengeNo, 등등)
- snackbar추가
- sideEffect handle추가
- 챌린지 삭제 dialog추가
- homeState, state, challengeInfo 결합

## 🔥 To Reviewers



## 📷 Screenshot
|기능|스크린샷|
|:---|---|
|기능A 구현|<img src = "" width = 400>|
|기능B 구현||
|...||
