### PR TITLE
짝꿍 이별, 회원 탈퇴 로직 추가

### DIFF
--- a/data/src/main/java/com/mashup/twotoo/datasource/local/UserPreferenceDataSource.kt
+++ b/data/src/main/java/com/mashup/twotoo/datasource/local/UserPreferenceDataSource.kt
@@ -68,6 +68,12 @@ class UserPreferenceDataSource @Inject constructor(
         return userInfo?.let { info -> jsonAdapter.fromJson(info) }
     }
 
+    suspend fun removeUserInfo() {
+        dataStore.edit {
+            it.remove(stringPreferencesKey(USER_INFO))
+        }
+    }
+
     private suspend fun <T> setDataStore(key: Preferences.Key<T>, value: T) {
         dataStore.edit { preferences ->
             preferences[key] = value

--- a/data/src/main/java/com/mashup/twotoo/datasource/remote/user/UserApi.kt
+++ b/data/src/main/java/com/mashup/twotoo/datasource/remote/user/UserApi.kt
@@ -6,6 +6,7 @@ import com.mashup.twotoo.datasource.remote.user.response.PartnerInfoResponse
 import com.mashup.twotoo.datasource.remote.user.response.UserAuthResponse
 import com.mashup.twotoo.datasource.remote.user.response.UserInfoResponse
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
@@ -26,4 +27,10 @@ interface UserApi {
 
     @GET("/user/me")
     suspend fun getUserInfo(): UserInfoResponse
+
+    @PATCH("/user/delPartner")
+    suspend fun deletePartner(): Boolean
+
+    @DELETE("/user/signOut")
+    suspend fun signOut(): Boolean
 }

--- a/data/src/main/java/com/mashup/twotoo/datasource/remote/user/UserDataSource.kt
+++ b/data/src/main/java/com/mashup/twotoo/datasource/remote/user/UserDataSource.kt
@@ -29,4 +29,12 @@ class UserDataSource @Inject constructor(
     suspend fun getUserInfo(): UserInfoResponse {
         return userApi.getUserInfo()
     }
+
+    suspend fun deletePartner(): Boolean {
+        return userApi.deletePartner()
+    }
+
+    suspend fun signOut(): Boolean {
+        return userApi.signOut()
+    }
 }

--- a/data/src/main/java/com/mashup/twotoo/repository/UserDataStoreRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/twotoo/repository/UserDataStoreRepositoryImpl.kt
@@ -18,6 +18,10 @@ class UserDataStoreRepositoryImpl @Inject constructor(
         return userPreferenceDataSource.getUserInfo()?.toDomainModel()
     }
 
+    override suspend fun removeUserInfo() {
+        return userPreferenceDataSource.removeUserInfo()
+    }
+
     override suspend fun getIsSendInvitation(): Boolean {
         return userPreferenceDataSource.getIsSendInvitation()
     }

--- a/data/src/main/java/com/mashup/twotoo/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/twotoo/repository/UserRepositoryImpl.kt
@@ -38,4 +38,16 @@ class UserRepositoryImpl @Inject constructor(
             userDataSource.getUserInfo().toDomainModel()
         }
     }
+
+    override suspend fun deletePartner(): Result<Boolean> {
+        return runCatching {
+            userDataSource.deletePartner()
+        }
+    }
+
+    override suspend fun signOut(): Result<Boolean> {
+        return runCatching {
+            userDataSource.signOut()
+        }
+    }
 }

--- a/domain/src/main/java/repository/UserDataStoreRepository.kt
+++ b/domain/src/main/java/repository/UserDataStoreRepository.kt
@@ -11,6 +11,7 @@ interface UserDataStoreRepository {
     suspend fun removeVisibilityCompleteDialog()
     suspend fun setUserInfo(userAuthResponseDomainModel: UserAuthResponseDomainModel)
     suspend fun getUserInfo(): UserAuthResponseDomainModel?
+    suspend fun removeUserInfo()
     suspend fun getIsSendInvitation(): Boolean
     suspend fun setIsSendInvitation(isSend: Boolean)
 }

--- a/domain/src/main/java/repository/UserRepository.kt
+++ b/domain/src/main/java/repository/UserRepository.kt
@@ -11,4 +11,6 @@ interface UserRepository {
     suspend fun setUserNickName(userNickNameDomainModel: UserNickNameDomainModel): Result<UserInfoDomainModel>
     suspend fun getPartnerInfo(): Result<PartnerInfoDomainModel>
     suspend fun getUserInfo(): Result<UserInfoDomainModel>
+    suspend fun deletePartner(): Result<Boolean>
+    suspend fun signOut(): Result<Boolean>
 }

--- a/domain/src/main/java/usecase/user/DeletePartnerUseCase.kt
+++ b/domain/src/main/java/usecase/user/DeletePartnerUseCase.kt
@@ -1,0 +1,12 @@
+package usecase.user
+
+import repository.UserRepository
+import javax.inject.Inject
+
+class DeletePartnerUseCase @Inject constructor(
+    private val userRepository: UserRepository
+) {
+    suspend operator fun invoke(): Result<Boolean> {
+        return userRepository.deletePartner()
+    }
+}

--- a/domain/src/main/java/usecase/user/RemoveUserInfoUseCase.kt
+++ b/domain/src/main/java/usecase/user/RemoveUserInfoUseCase.kt
@@ -1,0 +1,12 @@
+package usecase.user
+
+import repository.UserDataStoreRepository
+import javax.inject.Inject
+
+class RemoveUserInfoUseCase @Inject constructor(
+    private val userDataStoreRepository: UserDataStoreRepository,
+) {
+    suspend operator fun invoke() {
+        userDataStoreRepository.removeUserInfo()
+    }
+}

--- a/domain/src/main/java/usecase/user/SignOutUseCase.kt
+++ b/domain/src/main/java/usecase/user/SignOutUseCase.kt
@@ -1,0 +1,12 @@
+package usecase.user
+
+import repository.UserRepository
+import javax.inject.Inject
+
+class SignOutUseCase @Inject constructor(
+    private val userRepository: UserRepository
+) {
+    suspend operator fun invoke(): Result<Boolean> {
+        return userRepository.signOut()
+    }
+}

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/dialog/DialogContent.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/dialog/DialogContent.kt
@@ -85,6 +85,58 @@ class DialogContent private constructor(
                 ),
             ),
         )
+
+        fun createSignOutConfirmDialogContent(
+            negativeAction: () -> Unit,
+            positiveAction: () -> Unit,
+        ) = DialogContent(
+            title = R.string.sign_out_dialog_title,
+            desc = R.string.sign_out_dialog_content,
+            dialogImage = DialogImage.leaveChallenge,
+            buttons = listOf(
+                DialogButtonContent(
+                    text = R.string.cancel,
+                    action = negativeAction,
+                ),
+                DialogButtonContent(
+                    text = R.string.sign_out_dialog_positive,
+                    action = positiveAction,
+                ),
+            ),
+        )
+
+        fun createSignOutSuccessDialogContent(
+            positiveAction: () -> Unit,
+        ) = DialogContent(
+            title = R.string.sign_out_success_dialog,
+            desc = R.string.sign_out_success_dialog_content,
+            dialogImage = DialogImage.leaveChallenge,
+            buttons = listOf(
+                DialogButtonContent(
+                    text = R.string.button_confirm,
+                    action = positiveAction,
+                ),
+            ),
+        )
+
+        fun createDeletePartnerConfirmDialogContent(
+            negativeAction: () -> Unit,
+            positiveAction: () -> Unit,
+        ) = DialogContent(
+            title = R.string.delete_partner_dialog_title,
+            desc = R.string.delete_partner_dialog_content,
+            dialogImage = DialogImage.leaveChallenge,
+            buttons = listOf(
+                DialogButtonContent(
+                    text = R.string.cancel,
+                    action = negativeAction,
+                ),
+                DialogButtonContent(
+                    text = R.string.delete_partner_dialog_positive,
+                    action = positiveAction,
+                ),
+            ),
+        )
     }
 }
 

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/mypage/UserSideEffect.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/mypage/UserSideEffect.kt
@@ -1,0 +1,12 @@
+package com.mashup.twotoo.presenter.mypage
+
+sealed class UserSideEffect {
+    data class NavigateToRoute(val route: String) : UserSideEffect()
+    object OpenSignOutConfirmDialog : UserSideEffect()
+    object OpenSignOutSuccessDialog : UserSideEffect()
+    object OpenDeletePartnerConfirmDialog : UserSideEffect()
+}
+
+enum class MyPageDialogType {
+    SignOutConfirm, SignOutSuccess, DeletePartnerConfirm
+}

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/mypage/UserViewModel.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/mypage/UserViewModel.kt
@@ -2,18 +2,26 @@ package com.mashup.twotoo.presenter.mypage
 
 import androidx.lifecycle.ViewModel
 import com.mashup.twotoo.presenter.home.model.HomeGoalCountUiModel
+import com.mashup.twotoo.presenter.mypage.model.MyPageItem
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
+import usecase.user.DeletePartnerUseCase
 import usecase.user.GetUserInfoUseCase
+import usecase.user.RemoveUserInfoUseCase
+import usecase.user.SignOutUseCase
 import javax.inject.Inject
 
 class UserViewModel @Inject constructor(
     private val getUserInfoUseCase: GetUserInfoUseCase,
-) : ContainerHost<UserState, Nothing>, ViewModel() {
-    override val container: Container<UserState, Nothing> = container(
+    private val deletePartnerUseCase: DeletePartnerUseCase,
+    private val signOutUseCase: SignOutUseCase,
+    private val removeUserInfoUseCase: RemoveUserInfoUseCase
+) : ContainerHost<UserState, UserSideEffect>, ViewModel() {
+    override val container: Container<UserState, UserSideEffect> = container(
         UserState(),
     )
 
@@ -29,5 +37,36 @@ class UserViewModel @Inject constructor(
                 )
             }
         }
+    }
+
+    fun deletePartner() = intent {
+        deletePartnerUseCase().onSuccess { isSuccess ->
+            if (isSuccess) {
+                navigateToRoute(MyPageItem.DeletePartner.route)
+            }
+        }.onFailure {
+        }
+    }
+
+    fun signOut() = intent {
+        signOutUseCase().onSuccess { isSuccess ->
+            if (isSuccess) {
+                removeUserInfoUseCase()
+                postSideEffect(UserSideEffect.OpenSignOutSuccessDialog)
+            }
+        }.onFailure {
+        }
+    }
+
+    fun openSignOutConfirmDialog() = intent {
+        postSideEffect(UserSideEffect.OpenSignOutConfirmDialog)
+    }
+
+    fun openDeletePartnerConfirmDialog() = intent {
+        postSideEffect(UserSideEffect.OpenDeletePartnerConfirmDialog)
+    }
+
+    fun navigateToRoute(route: String) = intent {
+        postSideEffect(UserSideEffect.NavigateToRoute(route))
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/mypage/di/UserModule.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/mypage/di/UserModule.kt
@@ -3,7 +3,10 @@ package com.mashup.twotoo.presenter.mypage.di
 import com.mashup.twotoo.presenter.mypage.UserViewModel
 import dagger.Module
 import dagger.Provides
+import usecase.user.DeletePartnerUseCase
 import usecase.user.GetUserInfoUseCase
+import usecase.user.RemoveUserInfoUseCase
+import usecase.user.SignOutUseCase
 import javax.inject.Scope
 
 /**
@@ -17,9 +20,15 @@ class UserModule {
     @UserScope
     fun provideUserViewModel(
         getUserInfoUseCase: GetUserInfoUseCase,
+        deletePartnerUseCase: DeletePartnerUseCase,
+        signOutUseCase: SignOutUseCase,
+        removeUserInfoUseCase: RemoveUserInfoUseCase
     ): UserViewModel {
         return UserViewModel(
             getUserInfoUseCase = getUserInfoUseCase,
+            deletePartnerUseCase = deletePartnerUseCase,
+            signOutUseCase = signOutUseCase,
+            removeUserInfoUseCase = removeUserInfoUseCase,
         )
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/mypage/model/MyPageItem.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/mypage/model/MyPageItem.kt
@@ -11,6 +11,8 @@ enum class MyPageItem(@StringRes val value: Int, val route: String) {
     UsingGuide(value = R.string.using_guide, route = GuideUrlItem.UsingGuide.name),
     Inquiry(value = R.string.inquiry, route = GuideUrlItem.Inquiry.name),
     Makers(value = R.string.makers, route = GuideUrlItem.Makers.name),
+    DeletePartner(value = R.string.delete_matching, route = "deletePartner"),
+    SignOut(value = R.string.sign_out, route = "signOut")
 }
 
 enum class GuideUrlItem(val url: String, val title: String) {

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/mypage/navigation/UserNavigation.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/mypage/navigation/UserNavigation.kt
@@ -4,12 +4,16 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.navOptions
 import androidx.navigation.navigation
 import com.mashup.twotoo.presenter.di.daggerViewModel
 import com.mashup.twotoo.presenter.guid.navigation.navigateToGuide
 import com.mashup.twotoo.presenter.mypage.MyPageRoute
 import com.mashup.twotoo.presenter.mypage.di.UserComponentProvider
+import com.mashup.twotoo.presenter.mypage.model.MyPageItem
 import com.mashup.twotoo.presenter.navigation.NavigationRoute
+import com.mashup.twotoo.presenter.nickname.navigation.navigateToOnNickNameSetting
+import com.mashup.twotoo.presenter.onboarding.navigation.navigateToOnBoarding
 import com.mashup.twotoo.presenter.util.componentProvider
 
 fun NavController.navigateToUser(navOptions: NavOptions? = null) {
@@ -26,7 +30,28 @@ fun NavGraphBuilder.userGraph(navController: NavController) {
 
             MyPageRoute(
                 userViewModel = userViewModel,
-                navigateToGuide = { route -> navController.navigateToGuide(route) },
+                navigateToRoute = { route ->
+                    when (route) {
+                        MyPageItem.SignOut.route -> {
+                            navController.navigateToOnBoarding(
+                                navOptions = navOptions {
+                                    popUpTo(navController.graph.id) {
+                                        inclusive = true
+                                    }
+                                },
+                            )
+                        }
+                        MyPageItem.DeletePartner.route -> {
+                            navController.navigateToOnNickNameSetting(
+                                navOptions = navOptions {
+                                    popUpTo(navController.graph.id) {
+                                        inclusive = true
+                                    }
+                                },
+                            )
+                        }
+                        else -> { navController.navigateToGuide(route) } }
+                },
             )
         }
     }

--- a/presenter/src/main/res/values/string.xml
+++ b/presenter/src/main/res/values/string.xml
@@ -176,6 +176,18 @@
     <string name="using_guide">이용 가이드</string>
     <string name="inquiry">투투에 문의하기</string>
     <string name="makers">만든이들</string>
+    <string name="delete_matching">짝꿍 이별</string>
+    <string name="sign_out">회원 탈퇴</string>
+    <string name="sign_out_dialog_title">회원 탈퇴하기</string>
+    <string name="sign_out_dialog_content">정말로 회원을 탈퇴 하실건가요?</string>
+    <string name="sign_out_dialog_positive">탈퇴하기</string>
+    <string name="sign_out_success_dialog">회원 탈퇴 완료</string>
+    <string name="sign_out_success_dialog_content">아쉽지만 다음에 또 만나요!</string>
+    <string name="delete_partner_dialog_title">짝꿍과 이별</string>
+    <string name="delete_partner_dialog_content">짝꿍과 이별 시 모든 챌린지는 삭제됩니다.</string>
+    <string name="delete_partner_dialog_positive">이별하기</string>
+
+
 
     <!--flower language -->
     <string name="rose_language">행복한 사랑을 이루고 싶어요</string>


### PR DESCRIPTION
## 🔥 관련 이슈

close #229 

## 🔥 PR Point

- 회원 탈퇴 API 추가
- 짝꿍 이별 API 추가
- 회원 탈퇴 시 datestore 유저 정보 삭제 -> 온보딩 페이지 이동
- 짝꿍 이별 시 닉네임 설정 페이지 이동
- 각 다이얼로그 세팅

## 🔥 To Reviewers


