### PR TITLE
꽃말 2줄로 수정

### DIFF
--- a/presenter/src/main/java/com/mashup/twotoo/presenter/home/model/Flower.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/home/model/Flower.kt
@@ -77,10 +77,10 @@ data class Flower(
         return when (stage) {
             Zero -> Pair((53 * screenWidth / figmaScreenWidth).dp, (49 * screenHeight / figmaScreenHeight).dp)
             First -> Pair((76 * screenWidth / figmaScreenWidth).dp, (69 * screenHeight / figmaScreenHeight).dp)
-            Second -> Pair((77 * screenWidth / figmaScreenWidth).dp, (117 * screenHeight / figmaScreenHeight).dp)
-            Third -> Pair((102 * screenWidth / figmaScreenWidth).dp, (183 * screenHeight / figmaScreenHeight).dp)
-            Fourth -> Pair((113 * screenWidth / figmaScreenWidth).dp, (188 * screenHeight / figmaScreenHeight).dp)
-            Fifth -> Pair((113 * screenWidth / figmaScreenWidth).dp, (188 * screenHeight / figmaScreenHeight).dp)
+            Second -> Pair((81 * screenWidth / figmaScreenWidth).dp, (117 * screenHeight / figmaScreenHeight).dp)
+            Third -> Pair((102 * screenWidth / figmaScreenWidth).dp, (179 * screenHeight / figmaScreenHeight).dp)
+            Fourth -> Pair((127 * screenWidth / figmaScreenWidth).dp, (211 * screenHeight / figmaScreenHeight).dp)
+            Fifth -> Pair((127 * screenWidth / figmaScreenWidth).dp, (211 * screenHeight / figmaScreenHeight).dp)
         }
     }
 

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/home/ongoing/components/HomeFlowerLanguage.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/home/ongoing/components/HomeFlowerLanguage.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
@@ -30,9 +31,11 @@ fun HomeFlowerLanguage(
             color = TwoTooTheme.color.mainBrown,
         )
         Text(
-            text = (homeFlowerUiModel.flowerType as Flower).getFlowerLanguage(context = context),
+            text = homeFlowerUiModel.flowerType.getFlowerLanguage(context = context),
             style = TwoTooTheme.typography.bodyNormal14,
             color = TwoTooTheme.color.mainBrown,
+            textAlign = TextAlign.Center,
+            maxLines = 2,
         )
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/home/preview/parameter/PreviewCompleteHomeParameterProvider.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/home/preview/parameter/PreviewCompleteHomeParameterProvider.kt
@@ -2,11 +2,14 @@ package com.mashup.twotoo.presenter.home.preview.parameter
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.mashup.twotoo.presenter.home.model.AuthType
+import com.mashup.twotoo.presenter.home.model.Flower
 import com.mashup.twotoo.presenter.home.model.HomeChallengeStateUiModel
 import com.mashup.twotoo.presenter.home.model.HomeFlowerPartnerAndMeUiModel
 import com.mashup.twotoo.presenter.home.model.HomeFlowerUiModel
 import com.mashup.twotoo.presenter.home.model.HomeStateUiModel
 import com.mashup.twotoo.presenter.home.model.OngoingChallengeUiModel
+import com.mashup.twotoo.presenter.home.model.UserType
+import com.mashup.twotoo.presenter.model.FlowerName
 import com.mashup.twotoo.presenter.model.Stage
 
 class PreviewCompleteHomeParameterProvider : PreviewParameterProvider<HomeStateUiModel> {
@@ -17,6 +20,13 @@ class PreviewCompleteHomeParameterProvider : PreviewParameterProvider<HomeStateU
         completeThirdStageChallenge,
         completeFourthStageChallenge,
         completeFifthStageChallenge,
+        completeFifthStageRoseChallenge,
+        completeFifthStageCottonChallenge,
+        completeFifthStageFigChallenge,
+        completeFifthStageChrysanthemumChallenge,
+        completeFifthStageSunFlowerChallenge,
+        completeFifthStageCamelliaChallenge,
+        completeFifthStageDelphiniumChallenge,
     ).asSequence()
 
     companion object {
@@ -39,12 +49,34 @@ class PreviewCompleteHomeParameterProvider : PreviewParameterProvider<HomeStateU
         val completeFifthStageChallenge = HomeStateUiModel(
             challengeStateUiModel = getAuthUiModel(Stage.Fifth, Stage.Fifth),
         )
+        val completeFifthStageRoseChallenge = HomeStateUiModel(
+            challengeStateUiModel = getAuthUiModel(Stage.Fifth, Stage.Fifth, FlowerName.Rose),
+        )
+        val completeFifthStageCottonChallenge = HomeStateUiModel(
+            challengeStateUiModel = getAuthUiModel(Stage.Fifth, Stage.Fifth, FlowerName.Cotton),
+        )
+        val completeFifthStageFigChallenge = HomeStateUiModel(
+            challengeStateUiModel = getAuthUiModel(Stage.Fifth, Stage.Fifth, FlowerName.Fig),
+        )
+        val completeFifthStageChrysanthemumChallenge = HomeStateUiModel(
+            challengeStateUiModel = getAuthUiModel(Stage.Fifth, Stage.Fifth, FlowerName.Chrysanthemum),
+        )
+        val completeFifthStageSunFlowerChallenge = HomeStateUiModel(
+            challengeStateUiModel = getAuthUiModel(Stage.Fifth, Stage.Fifth, FlowerName.Sunflower),
+        )
+        val completeFifthStageCamelliaChallenge = HomeStateUiModel(
+            challengeStateUiModel = getAuthUiModel(Stage.Fifth, Stage.Fifth, FlowerName.Camellia),
+        )
+        val completeFifthStageDelphiniumChallenge = HomeStateUiModel(
+            challengeStateUiModel = getAuthUiModel(Stage.Fifth, Stage.Fifth, FlowerName.Delphinium),
+        )
     }
 }
 
 private fun getAuthUiModel(
     partnerStage: Stage,
     meStage: Stage,
+    flowerName: FlowerName = FlowerName.Tulip,
 ): OngoingChallengeUiModel {
     return OngoingChallengeUiModel.default.copy(
         homeChallengeStateUiModel = HomeChallengeStateUiModel.complete.copy(
@@ -56,7 +88,13 @@ private fun getAuthUiModel(
                     Stage.Second -> HomeFlowerUiModel.partnerSecondState
                     Stage.Third -> HomeFlowerUiModel.partnerThirdState
                     Stage.Fourth -> HomeFlowerUiModel.partnerFourthState
-                    Stage.Fifth -> HomeFlowerUiModel.partnerFifthState
+                    Stage.Fifth -> HomeFlowerUiModel.partnerFifthState.copy(
+                        flowerType = Flower(
+                            flowerName = flowerName,
+                            userType = UserType.PARTNER,
+                            growType = Stage.Fifth,
+                        ),
+                    )
                 },
                 me = when (meStage) {
                     Stage.Zero -> HomeFlowerUiModel.meZeroState
@@ -64,7 +102,13 @@ private fun getAuthUiModel(
                     Stage.Second -> HomeFlowerUiModel.meSecondState
                     Stage.Third -> HomeFlowerUiModel.meThirdState
                     Stage.Fourth -> HomeFlowerUiModel.meFourthState
-                    Stage.Fifth -> HomeFlowerUiModel.meFifthState
+                    Stage.Fifth -> HomeFlowerUiModel.meFifthState.copy(
+                        flowerType = Flower(
+                            flowerName = flowerName,
+                            userType = UserType.ME,
+                            growType = Stage.Fifth,
+                        ),
+                    )
                 },
             ),
         ),

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/home/preview/parameter/PreviewOngoingCheerHomeParameterProvider.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/home/preview/parameter/PreviewOngoingCheerHomeParameterProvider.kt
@@ -3,11 +3,14 @@ package com.mashup.twotoo.presenter.home.preview.parameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.mashup.twotoo.presenter.home.model.CheerState
 import com.mashup.twotoo.presenter.home.model.CheerWithFlower
+import com.mashup.twotoo.presenter.home.model.Flower
 import com.mashup.twotoo.presenter.home.model.HomeChallengeStateUiModel
 import com.mashup.twotoo.presenter.home.model.HomeCheerUiModel
 import com.mashup.twotoo.presenter.home.model.HomeFlowerUiModel
 import com.mashup.twotoo.presenter.home.model.HomeStateUiModel
 import com.mashup.twotoo.presenter.home.model.OngoingChallengeUiModel
+import com.mashup.twotoo.presenter.home.model.UserType
+import com.mashup.twotoo.presenter.model.FlowerName
 import com.mashup.twotoo.presenter.model.Stage
 
 class PreviewCheerHomeParameterProvider : PreviewParameterProvider<HomeStateUiModel> {
@@ -20,6 +23,14 @@ class PreviewCheerHomeParameterProvider : PreviewParameterProvider<HomeStateUiMo
         ongoingCheerChallengeFirstStage,
         ongoingCheerChallengeSecondStage,
         ongoingCheerChallengeThirdStage,
+        ongoingCheerChallengeFourthStage,
+        ongoingCheerChallengeRoseFourthStage,
+        ongoingCheerChallengeCottonFourthStage,
+        ongoingCheerChallengeFigFourthStage,
+        ongoingCheerChallengeChrysanthemumFourthStage,
+        ongoingCheerChallengeSunFlowerFourthStage,
+        ongoingCheerChallengeCamelliaFourthStage,
+        ongoingCheerChallengeDelphiniumFourthStage,
     ).asSequence()
 
     companion object {
@@ -52,6 +63,30 @@ class PreviewCheerHomeParameterProvider : PreviewParameterProvider<HomeStateUiMo
         val ongoingCheerChallengeThirdStage = HomeStateUiModel(
             challengeStateUiModel = getCheerUiModel(Stage.Third, Stage.Third, cheerState = CheerState.CheerBoth),
         )
+        val ongoingCheerChallengeFourthStage = HomeStateUiModel(
+            challengeStateUiModel = getCheerUiModel(Stage.Fourth, Stage.Fourth, cheerState = CheerState.CheerBoth),
+        )
+        val ongoingCheerChallengeRoseFourthStage = HomeStateUiModel(
+            challengeStateUiModel = getCheerUiModel(Stage.Fourth, Stage.Fourth, cheerState = CheerState.CheerBoth, flowerName = FlowerName.Rose),
+        )
+        val ongoingCheerChallengeCottonFourthStage = HomeStateUiModel(
+            challengeStateUiModel = getCheerUiModel(Stage.Fourth, Stage.Fourth, cheerState = CheerState.CheerBoth, flowerName = FlowerName.Cotton),
+        )
+        val ongoingCheerChallengeFigFourthStage = HomeStateUiModel(
+            challengeStateUiModel = getCheerUiModel(Stage.Fourth, Stage.Fourth, cheerState = CheerState.CheerBoth, flowerName = FlowerName.Fig),
+        )
+        val ongoingCheerChallengeChrysanthemumFourthStage = HomeStateUiModel(
+            challengeStateUiModel = getCheerUiModel(Stage.Fourth, Stage.Fourth, cheerState = CheerState.CheerBoth, flowerName = FlowerName.Chrysanthemum),
+        )
+        val ongoingCheerChallengeSunFlowerFourthStage = HomeStateUiModel(
+            challengeStateUiModel = getCheerUiModel(Stage.Fourth, Stage.Fourth, cheerState = CheerState.CheerBoth, flowerName = FlowerName.Sunflower),
+        )
+        val ongoingCheerChallengeCamelliaFourthStage = HomeStateUiModel(
+            challengeStateUiModel = getCheerUiModel(Stage.Fourth, Stage.Fourth, cheerState = CheerState.CheerBoth, flowerName = FlowerName.Camellia),
+        )
+        val ongoingCheerChallengeDelphiniumFourthStage = HomeStateUiModel(
+            challengeStateUiModel = getCheerUiModel(Stage.Fourth, Stage.Fourth, cheerState = CheerState.CheerBoth, flowerName = FlowerName.Delphinium),
+        )
     }
 }
 
@@ -59,6 +94,7 @@ private fun getCheerUiModel(
     partnerStage: Stage,
     meStage: Stage,
     cheerState: CheerState,
+    flowerName: FlowerName = FlowerName.Tulip,
 ): OngoingChallengeUiModel {
     return OngoingChallengeUiModel.cheer.copy(
         homeChallengeStateUiModel = HomeChallengeStateUiModel.cheerBoth.copy(
@@ -71,7 +107,13 @@ private fun getCheerUiModel(
                         Stage.Second -> HomeFlowerUiModel.partnerSecondState
                         Stage.Third -> HomeFlowerUiModel.partnerThirdState
                         Stage.Fourth -> HomeFlowerUiModel.partnerFourthState
-                        Stage.Fifth -> HomeFlowerUiModel.partnerFifthState
+                        Stage.Fifth -> HomeFlowerUiModel.partnerFifthState.copy(
+                            flowerType = Flower(
+                                flowerName = flowerName,
+                                userType = UserType.PARTNER,
+                                growType = Stage.Fifth,
+                            ),
+                        )
                     },
                 ),
                 me = if (cheerState == CheerState.CheerOnlyPartner) {
@@ -82,7 +124,13 @@ private fun getCheerUiModel(
                             Stage.Second -> HomeFlowerUiModel.meSecondState
                             Stage.Third -> HomeFlowerUiModel.meThirdState
                             Stage.Fourth -> HomeFlowerUiModel.meFourthState
-                            Stage.Fifth -> HomeFlowerUiModel.meFifthState
+                            Stage.Fifth -> HomeFlowerUiModel.meFifthState.copy(
+                                flowerType = Flower(
+                                    flowerName = flowerName,
+                                    userType = UserType.PARTNER,
+                                    growType = Stage.Fifth,
+                                ),
+                            )
                         },
                     )
                 } else {

--- a/presenter/src/main/res/values/string.xml
+++ b/presenter/src/main/res/values/string.xml
@@ -190,11 +190,11 @@
 
 
     <!--flower language -->
-    <string name="rose_language">행복한 사랑을 이루고 싶어요</string>
-    <string name="tulip_language">수줍은 사랑을 주고 싶어요</string>
+    <string name="rose_language">행복한 사랑을\n이루고 싶어요</string>
+    <string name="tulip_language">수줍은 사랑을\n주고 싶어요</string>
     <string name="fig_language">사랑의 결실을 맺어봐요</string>
     <string name="cotton_language">온기를 담아 사랑해요</string>
-    <string name="delphinium_language">당신을 행복하게 해줄게요</string>
+    <string name="delphinium_language">당신을 행복하게\n해줄게요</string>
     <string name="camellia_language">그 누구보다 사랑해요</string>
     <string name="chrysanthemum_language">제 마음은 늘 진심이에요</string>
     <string name="sunflower_language">당신을 바라보고 싶어요</string>


### PR DESCRIPTION
## 🔥 관련 이슈

close #242 

## 🔥 PR Point
- 디자인팀의 수정사항으로 꽃말이 겹치는 이슈가 있다고 하여 긴것은 2줄로 보이게 수정합니다.

## 🔥 To Reviewers



## 📷 Screenshot
|기능|스크린샷|
|:---|---|
|3개의 꽃말 2줄 수정|<img width="1081" alt="스크린샷 2023-08-18 오후 5 18 03" src="https://github.com/mash-up-kr/TwoToo_Android/assets/62296097/20a7cf4b-6f7e-4f2a-9851-a37e136f30d0">|
