### PR TITLE
API Repsonse 에러 처리 커스텀

### DIFF
--- a/data/src/main/java/com/mashup/twotoo/datasource/remote/user/UserApi.kt
+++ b/data/src/main/java/com/mashup/twotoo/datasource/remote/user/UserApi.kt
@@ -1,5 +1,6 @@
 package com.mashup.twotoo.datasource.remote.user
 
+import util.NetworkResult
 import com.mashup.twotoo.datasource.remote.user.request.UserAuthRequest
 import com.mashup.twotoo.datasource.remote.user.request.UserNickNameRequest
 import com.mashup.twotoo.datasource.remote.user.response.PartnerInfoResponse
@@ -26,7 +27,7 @@ interface UserApi {
     suspend fun getUserPartnerInfo(): PartnerInfoResponse
 
     @GET("/user/me")
-    suspend fun getUserInfo(): UserInfoResponse
+    suspend fun getUserInfo(): NetworkResult<UserInfoResponse>
 
     @PATCH("/user/delPartner")
     suspend fun deletePartner(): Boolean

--- a/data/src/main/java/com/mashup/twotoo/datasource/remote/user/UserDataSource.kt
+++ b/data/src/main/java/com/mashup/twotoo/datasource/remote/user/UserDataSource.kt
@@ -1,5 +1,6 @@
 package com.mashup.twotoo.datasource.remote.user
 
+import util.NetworkResult
 import com.mashup.twotoo.datasource.remote.user.request.UserAuthRequest
 import com.mashup.twotoo.datasource.remote.user.request.UserNickNameRequest
 import com.mashup.twotoo.datasource.remote.user.response.PartnerInfoResponse
@@ -26,7 +27,7 @@ class UserDataSource @Inject constructor(
         return userApi.getUserPartnerInfo()
     }
 
-    suspend fun getUserInfo(): UserInfoResponse {
+    suspend fun getUserInfo(): NetworkResult<UserInfoResponse> {
         return userApi.getUserInfo()
     }
 

--- a/data/src/main/java/com/mashup/twotoo/di/NetworkModule.kt
+++ b/data/src/main/java/com/mashup/twotoo/di/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.mashup.twotoo.di
 
 import com.mashup.twotoo.data.BuildConfig
+import com.mashup.twotoo.util.NetworkResultCallAdapterFactory
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
@@ -69,7 +70,7 @@ class NetworkModule {
         return Retrofit.Builder().baseUrl(URL)
             .client(client).addConverterFactory(
                 moshiConverterFactory,
-            ).build()
+            ).addCallAdapterFactory(NetworkResultCallAdapterFactory.create()).build()
     }
 
     @Provides

--- a/data/src/main/java/com/mashup/twotoo/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/twotoo/repository/UserRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.mashup.twotoo.repository
 
+import util.NetworkResult
 import com.mashup.twotoo.datasource.remote.user.UserDataSource
 import com.mashup.twotoo.datasource.remote.user.response.toDomainModel
 import com.mashup.twotoo.mapper.toDataModel
@@ -33,9 +34,10 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getUserInfo(): Result<UserInfoDomainModel> {
-        return runCatching {
-            userDataSource.getUserInfo().toDomainModel()
+    override suspend fun getUserInfo(): NetworkResult<UserInfoDomainModel> {
+        val result = userDataSource.getUserInfo()
+        return result.map { userInfoResponse ->
+            userInfoResponse.toDomainModel()
         }
     }
 

--- a/data/src/main/java/com/mashup/twotoo/util/HandleCoroutineApi.kt
+++ b/data/src/main/java/com/mashup/twotoo/util/HandleCoroutineApi.kt
@@ -1,0 +1,23 @@
+package com.mashup.twotoo.util
+
+import util.NetworkResult
+import retrofit2.HttpException
+import retrofit2.Response
+
+suspend fun <T : Any> handleApi(
+    execute: suspend () -> Response<T>
+): NetworkResult<T> {
+    return try {
+        val response = execute()
+        val body = response.body()
+        if (response.isSuccessful && body != null) {
+            NetworkResult.ApiSuccess(body)
+        } else {
+            NetworkResult.ApiError(code = response.code(), error = response.message())
+        }
+    } catch (e: HttpException) {
+        NetworkResult.ApiError(code = e.code(), error = e.message())
+    } catch (e: Throwable) {
+        NetworkResult.ApiException(e)
+    }
+}

--- a/data/src/main/java/com/mashup/twotoo/util/NetworkResultCall.kt
+++ b/data/src/main/java/com/mashup/twotoo/util/NetworkResultCall.kt
@@ -1,0 +1,40 @@
+package com.mashup.twotoo.util
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import okhttp3.Request
+import okio.Timeout
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import util.NetworkResult
+
+class NetworkResultCall<T : Any>(
+    private val proxy: Call<T>,
+    private val coroutineScope: CoroutineScope,
+) : Call<NetworkResult<T>> {
+
+    override fun execute(): Response<NetworkResult<T>> = throw NotImplementedError()
+    override fun enqueue(callback: Callback<NetworkResult<T>>) {
+        proxy.enqueue(object : Callback<T> {
+            override fun onResponse(call: Call<T>, response: Response<T>) {
+                coroutineScope.launch {
+                    val networkResult = handleApi { response }
+                    callback.onResponse(this@NetworkResultCall, Response.success(networkResult))
+                }
+            }
+
+            override fun onFailure(call: Call<T>, t: Throwable) {
+                val networkResult = NetworkResult.ApiException<T>(t)
+                callback.onResponse(this@NetworkResultCall, Response.success(networkResult))
+            }
+        })
+    }
+
+    override fun clone(): Call<NetworkResult<T>> = NetworkResultCall(proxy.clone(), coroutineScope)
+    override fun request(): Request = proxy.request()
+    override fun timeout(): Timeout = proxy.timeout()
+    override fun isExecuted(): Boolean = proxy.isExecuted
+    override fun isCanceled(): Boolean = proxy.isCanceled
+    override fun cancel() { proxy.cancel() }
+}

--- a/data/src/main/java/com/mashup/twotoo/util/NetworkResultCallAdapter.kt
+++ b/data/src/main/java/com/mashup/twotoo/util/NetworkResultCallAdapter.kt
@@ -1,0 +1,19 @@
+package com.mashup.twotoo.util
+
+import kotlinx.coroutines.CoroutineScope
+import retrofit2.Call
+import retrofit2.CallAdapter
+import util.NetworkResult
+import java.lang.reflect.Type
+
+class NetworkResultCallAdapter(
+    private val resultType: Type,
+    private val coroutineScope: CoroutineScope
+) : CallAdapter<Type, Call<NetworkResult<Type>>> {
+
+    override fun responseType(): Type = resultType
+
+    override fun adapt(call: Call<Type>): Call<NetworkResult<Type>> {
+        return NetworkResultCall(call, coroutineScope)
+    }
+}

--- a/data/src/main/java/com/mashup/twotoo/util/NetworkResultCallAdapterFactory.kt
+++ b/data/src/main/java/com/mashup/twotoo/util/NetworkResultCallAdapterFactory.kt
@@ -1,0 +1,38 @@
+package com.mashup.twotoo.util
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Retrofit
+import util.NetworkResult
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+class NetworkResultCallAdapterFactory private constructor(
+    private val coroutineScope: CoroutineScope
+) : CallAdapter.Factory() {
+
+    override fun get(
+        returnType: Type,
+        annotations: Array<out Annotation>,
+        retrofit: Retrofit
+    ): CallAdapter<*, *>? {
+        if (getRawType(returnType) != Call::class.java) {
+            return null
+        }
+
+        val callType = getParameterUpperBound(0, returnType as ParameterizedType)
+        if (getRawType(callType) != NetworkResult::class.java) {
+            return null
+        }
+
+        val resultType = getParameterUpperBound(0, callType as ParameterizedType)
+        return NetworkResultCallAdapter(resultType, coroutineScope)
+    }
+
+    companion object {
+        fun create(coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO)): NetworkResultCallAdapterFactory =
+            NetworkResultCallAdapterFactory(coroutineScope)
+    }
+}

--- a/domain/src/main/java/repository/UserRepository.kt
+++ b/domain/src/main/java/repository/UserRepository.kt
@@ -1,5 +1,6 @@
 package repository
 
+import util.NetworkResult
 import model.user.PartnerInfoDomainModel
 import model.user.UserAuthRequestDomainModel
 import model.user.UserAuthResponseDomainModel
@@ -10,7 +11,7 @@ interface UserRepository {
     suspend fun userAuthorize(userAuthRequestDomainModel: UserAuthRequestDomainModel): Result<UserAuthResponseDomainModel>
     suspend fun setUserNickName(userNickNameDomainModel: UserNickNameDomainModel): Result<UserInfoDomainModel>
     suspend fun getPartnerInfo(): Result<PartnerInfoDomainModel>
-    suspend fun getUserInfo(): Result<UserInfoDomainModel>
+    suspend fun getUserInfo(): NetworkResult<UserInfoDomainModel>
     suspend fun deletePartner(): Result<Boolean>
     suspend fun signOut(): Result<Boolean>
 }

--- a/domain/src/main/java/usecase/user/GetUserInfoUseCase.kt
+++ b/domain/src/main/java/usecase/user/GetUserInfoUseCase.kt
@@ -1,5 +1,6 @@
 package usecase.user
 
+import util.NetworkResult
 import model.user.UserInfoDomainModel
 import repository.UserRepository
 import javax.inject.Inject
@@ -7,7 +8,7 @@ import javax.inject.Inject
 class GetUserInfoUseCase @Inject constructor(
     private val userRepository: UserRepository
 ) {
-    suspend operator fun invoke(): Result<UserInfoDomainModel> {
+    suspend operator fun invoke(): NetworkResult<UserInfoDomainModel> {
         return userRepository.getUserInfo()
     }
 }

--- a/domain/src/main/java/util/NetworkResult.kt
+++ b/domain/src/main/java/util/NetworkResult.kt
@@ -1,0 +1,15 @@
+package util
+
+sealed class NetworkResult<T : Any> {
+    class ApiSuccess<T : Any>(val data: T) : NetworkResult<T>()
+    class ApiError<T : Any>(val code: Int, val error: String) : NetworkResult<T>()
+    class ApiException<T : Any>(val e: Throwable) : NetworkResult<T>()
+
+    inline fun <R : Any> map(transform: (T) -> R): NetworkResult<R> {
+        return when (this) {
+            is ApiSuccess -> ApiSuccess(transform(data))
+            is ApiError -> ApiError(code, error)
+            is ApiException -> ApiException(e)
+        }
+    }
+}

--- a/domain/src/main/java/util/NetworkResultExtensions.kt
+++ b/domain/src/main/java/util/NetworkResultExtensions.kt
@@ -1,0 +1,24 @@
+package util
+suspend fun <T : Any> NetworkResult<T>.onSuccess(
+    executable: suspend (T) -> Unit
+): NetworkResult<T> = apply {
+    if (this is NetworkResult.ApiSuccess<T>) {
+        executable(data)
+    }
+}
+
+suspend fun <T : Any> NetworkResult<T>.onError(
+    executable: suspend (code: Int, message: String?) -> Unit
+): NetworkResult<T> = apply {
+    if (this is NetworkResult.ApiError<T>) {
+        executable(code, error)
+    }
+}
+
+suspend fun <T : Any> NetworkResult<T>.onException(
+    executable: suspend (e: Throwable) -> Unit
+): NetworkResult<T> = apply {
+    if (this is NetworkResult.ApiException<T>) {
+        executable(e)
+    }
+}

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/invite/InviteViewModel.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/invite/InviteViewModel.kt
@@ -11,6 +11,8 @@ import com.mashup.twotoo.presenter.constant.TAG
 import com.mashup.twotoo.presenter.util.createInviteDeepLink
 import kotlinx.coroutines.launch
 import model.user.UserNickNameDomainModel
+import util.onError
+import util.onSuccess
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
@@ -43,7 +45,7 @@ class InviteViewModel @Inject constructor(
             } else {
                 postSideEffect(InviteSideEffect.SendSharedInvitation)
             }
-        }.onFailure {
+        }.onError { code, message ->
         }
     }
 

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/mypage/UserViewModel.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/mypage/UserViewModel.kt
@@ -3,6 +3,7 @@ package com.mashup.twotoo.presenter.mypage
 import androidx.lifecycle.ViewModel
 import com.mashup.twotoo.presenter.home.model.HomeGoalCountUiModel
 import com.mashup.twotoo.presenter.mypage.model.MyPageItem
+import util.onSuccess
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent


### PR DESCRIPTION
## 🔥 관련 이슈

close #218 

## 🔥 PR Point
- https://proandroiddev.com/modeling-retrofit-responses-with-sealed-classes-and-coroutines-9d6302077dfe
skydoves님이 만든 sandwich 라이브러리 참고해서 만들었습니다~! 
- retrofit에 addCallAdapterFactory custom하는 방법을 해보고싶어서 참고해서 만들어봤습니다. runcatching으로 감싸주었던 부분을 handleApi { } 로 바꿔주어야하는데  callAdapter를 사용하면 retrofit 반환 자체를 커스텀한 NetworkResult로 반환해서 그 과정이 필요없게 됩니다.
- 어떻게 하면 기존 코드를 덜 건드릴 수 있을까 하다가.. 기존에 Result 사용할 때 viewModel에서 onSuccess / onFail 를 사용해서 같은 방식으로 사용할 수 있는 extension 만들었습니다. ->  `NetworkResultExtensions`


## 🔥 To Reviewers
저도 공부하면서 코드 작성해봤는데 어렵더라구요! 다같이 회의때 봐도 좋을 것 같아요
우선 테스트겸 getUserInfo 가져오는 API 만 수정했고 나머지는 다같이 나눠서 하던지..이야기해보고 수정하는게 좋을 것 같아용

- NetworkResult는 presentation, domain, data모듈에서 전부 사용해서 domain모듈에 넣었는데 맞겠죠,,?

*참고자료
https://pluu.github.io/blog/android/2023/04/29/custom-calladapter-factory/
 https://proandroiddev.com/modeling-retrofit-responses-with-sealed-classes-and-coroutines-9d6302077dfe
https://velog.io/@suev72/AndroidRetrofit-Call-adapter