### PR TITLE
인증사진을 줌하거나 저장하는 로직 추가

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,8 @@ coroutine_test = "1.7.2"
 bottomsheetdialog = "1.2.1"
 extensions-compose-keyboard-state = "1.4.3"
 lottie = "6.1.0"
+capture = "1.0.3"
+
 
 [libraries]
 core-ktx = { module = "androidx.core:core-ktx", version.ref = "core_ktx" }
@@ -122,6 +124,9 @@ compose-keyboard-state = { module = "tech.thdev:extensions-compose-keyboard-stat
 
 #lottie
 lottie = { module = "com.airbnb.android:lottie-compose", version.ref = "lottie" }
+
+#capturable
+capture = { module ="dev.shreyaspatil:capturable", version.ref = "capture" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android_gradle_plugin" }

--- a/presenter/build.gradle.kts
+++ b/presenter/build.gradle.kts
@@ -88,6 +88,7 @@ dependencies {
     implementation(libs.bottomsheetdialog)
     implementation(libs.compose.keyboard.state)
     implementation(libs.lottie)
+    implementation(libs.capture)
 }
 
 fun getApiKey(propertyKey: String): String {

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/toast/TwoTooSnackbar.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/toast/TwoTooSnackbar.kt
@@ -35,7 +35,7 @@ fun SnackBarHost(modifier: Modifier, snackState: SnackbarHostState) {
 }
 
 @Composable
-fun TwoTooSnackBarView(
+private fun TwoTooSnackBarView(
     message: String,
 ) {
     Card(

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/toolbar/TwoTooBackToolbar.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/designsystem/component/toolbar/TwoTooBackToolbar.kt
@@ -23,6 +23,7 @@ fun TwoTooBackToolbar(
     titleModifier: Modifier = Modifier,
     @DrawableRes backIconId: Int = R.drawable.ic_back,
     color: Color = Color.Transparent,
+    contentColor: Color? = null,
     actionIconButton: @Composable () -> Unit = {},
 ) {
     TopAppBar(
@@ -34,7 +35,7 @@ fun TwoTooBackToolbar(
                 Text(
                     text = title,
                     modifier = titleModifier,
-                    color = TwoTooTheme.color.mainBrown,
+                    color = contentColor ?: TwoTooTheme.color.mainBrown,
                     style = TwoTooTheme.typography.headLineNormal24,
                     textAlign = TextAlign.Center,
                 )
@@ -48,6 +49,7 @@ fun TwoTooBackToolbar(
                     Icon(
                         painter = painterResource(id = backIconId),
                         contentDescription = null,
+                        tint = contentColor ?: LocalContentColor.current,
                     )
                 }
             }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/history/datail/HistoryDetailScreen.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/history/datail/HistoryDetailScreen.kt
@@ -36,6 +36,7 @@ fun HistoryDetailRoute(
     commitNo: Int,
     historyViewModel: HistoryViewModel,
     onClickBackButton: () -> Unit,
+    onClickImage: (String) -> Unit,
 ) {
     Log.i("HistoryDetailRoute", "commitNo = $commitNo")
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -46,15 +47,17 @@ fun HistoryDetailRoute(
     }
     val state by historyViewModel.collectAsState()
     HistoryDetailScreen(
-        onClickBackButton = onClickBackButton,
         historyDetailInfoUiModel = state.historyDetailInfoUiModel,
+        onClickBackButton = onClickBackButton,
+        onClickImage = onClickImage,
     )
 }
 
 @Composable
 fun HistoryDetailScreen(
-    onClickBackButton: () -> Unit,
     historyDetailInfoUiModel: HistoryDetailInfoUiModel,
+    onClickBackButton: () -> Unit = {},
+    onClickImage: (String) -> Unit = {},
 ) {
     val scrollableState = rememberScrollState()
 
@@ -98,7 +101,10 @@ fun HistoryDetailScreen(
                         .fillMaxWidth()
                         .padding(vertical = 24.dp)
                         .aspectRatio(1f)
-                        .clip(TwoTooTheme.shape.extraSmall),
+                        .clip(TwoTooTheme.shape.extraSmall).clickable {
+                            onClickImage(historyDetailInfoUiModel.infoUiModel.photoUrl)
+                        },
+
                 )
                 Text(
                     text = historyDetailInfoUiModel.challengeName,

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/history/detailImage/DetailImageScreen.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/history/detailImage/DetailImageScreen.kt
@@ -1,0 +1,220 @@
+package com.mashup.twotoo.presenter.history.detailImage
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
+import com.mashup.twotoo.presenter.R
+import com.mashup.twotoo.presenter.designsystem.component.TwoTooImageView
+import com.mashup.twotoo.presenter.designsystem.component.toast.SnackBarHost
+import com.mashup.twotoo.presenter.designsystem.component.toolbar.TwoTooBackToolbar
+import com.mashup.twotoo.presenter.designsystem.theme.TwoTooTheme
+import com.mashup.twotoo.presenter.util.saveBitmapToStorage
+import dev.shreyaspatil.capturable.Capturable
+import dev.shreyaspatil.capturable.controller.rememberCaptureController
+import kotlinx.coroutines.launch
+
+@Composable
+fun DetailImageRoute(
+    url: String,
+    onClickBackButton: () -> Unit = {},
+) {
+    DetailImageScreen(
+        modifier = Modifier.fillMaxSize(),
+        url = url,
+        onClickBackButton = onClickBackButton,
+    )
+}
+
+@Composable
+fun DetailImageScreen(
+    url: String,
+    modifier: Modifier = Modifier,
+    onClickBackButton: () -> Unit = {},
+) {
+    var scale by remember { mutableFloatStateOf(1f) }
+    var offsetX by remember { mutableFloatStateOf(0f) }
+    var offsetY by remember { mutableFloatStateOf(0f) }
+    var settingMenuVisibility by remember { mutableStateOf(false) }
+    val captureController = rememberCaptureController()
+    val context = LocalContext.current
+
+    val screenWidth = LocalConfiguration.current.screenWidthDp.toFloat()
+    val snackbarHostState: SnackbarHostState = remember { SnackbarHostState() }
+    val successToastText = stringResource(id = R.string.saveImageSuccessToastText)
+    val errorToastText = stringResource(id = R.string.saveImageErrorToastText)
+    val coroutineScope = rememberCoroutineScope()
+
+    ConstraintLayout(
+        modifier = modifier
+            .background(color = Color.Black)
+            .pointerInput(Unit) {
+                detectTransformGestures(
+                    onGesture = { _, pan, gestureZoom, _ ->
+                        scale = (scale * gestureZoom).coerceIn(1f, 5f)
+                        if (scale > 1) {
+                            offsetX += pan.x * scale
+                            offsetY += pan.y * scale
+                            offsetX = offsetX.coerceIn(-screenWidth, screenWidth)
+                            offsetY = offsetY.coerceIn(-screenWidth, screenWidth)
+                        } else {
+                            offsetX = 0f
+                            offsetY = 0f
+                        }
+                    },
+                )
+            }
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    onDoubleTap = {
+                        scale = 1f
+                        offsetX = 0f
+                        offsetY = 0f
+                    },
+                )
+            },
+    ) {
+        val (topBar, image, captureWrapper, dropDownMenu, snackBar) = createRefs()
+        TwoTooBackToolbar(
+            modifier = Modifier.constrainAs(topBar) {
+                top.linkTo(parent.top)
+                start.linkTo(parent.start)
+                end.linkTo(parent.end)
+            },
+            onClickBackIcon = {
+                onClickBackButton()
+            },
+            contentColor = Color.White,
+        ) {
+            IconButton(
+                onClick = {
+                    settingMenuVisibility = true
+                },
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_more),
+                    contentDescription = null,
+                    tint = Color.White,
+                )
+            }
+            DropdownMenu(
+                modifier = Modifier
+                    .wrapContentHeight()
+                    .constrainAs(dropDownMenu) {
+                        top.linkTo(topBar.bottom)
+                        end.linkTo(parent.end)
+                    },
+                expanded = settingMenuVisibility,
+                onDismissRequest = { settingMenuVisibility = false },
+            ) {
+                DropdownMenuItem(text = {
+                    Text(text = stringResource(id = R.string.saveImage))
+                }, onClick = {
+                    captureController.capture(Bitmap.Config.ARGB_8888)
+                })
+            }
+        }
+
+        Capturable(
+            modifier = Modifier.constrainAs(captureWrapper) {
+                centerHorizontallyTo(parent)
+                centerVerticallyTo(parent)
+                height = Dimension.ratio("1:1")
+            },
+            controller = captureController,
+            onCaptured = { bitmap, error ->
+                if (bitmap != null) {
+                    saveBitmapToStorage(
+                        context = context,
+                        bitmap = bitmap.asAndroidBitmap(),
+                        title = url,
+                        onSuccessToSave = {
+                            coroutineScope.launch {
+                                snackbarHostState.showSnackbar(successToastText)
+                            }
+                            settingMenuVisibility = false
+                        },
+                        onFailToSave = {
+                            coroutineScope.launch {
+                                snackbarHostState.showSnackbar(errorToastText)
+                            }
+                            settingMenuVisibility = false
+                        },
+                    )
+                }
+                if (error != null) {
+                    coroutineScope.launch {
+                        snackbarHostState.showSnackbar(errorToastText)
+                    }
+                    settingMenuVisibility = false
+                }
+            },
+        ) {
+            TwoTooImageView(
+                modifier = Modifier
+                    .constrainAs(image) {
+                        linkTo(
+                            start = parent.start,
+                            end = parent.end,
+                            top = parent.top,
+                            bottom = parent.bottom,
+                        )
+                    }
+                    .graphicsLayer {
+                        scaleX = scale
+                        scaleY = scale
+                        translationX = offsetX
+                        translationY = offsetY
+                    },
+                model = url,
+                contentScale = ContentScale.Fit,
+                previewPlaceholder = R.drawable.empty_image_color_placeholder,
+            )
+        }
+        SnackBarHost(
+            modifier = Modifier.constrainAs(snackBar) {
+                start.linkTo(parent.start)
+                end.linkTo(parent.end)
+                bottom.linkTo(parent.bottom, margin = 30.dp)
+            },
+            snackState = snackbarHostState,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewDetailImageScreen() {
+    TwoTooTheme {
+        DetailImageRoute(url = "")
+    }
+}

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/history/navigation/HistoryNavigation.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/history/navigation/HistoryNavigation.kt
@@ -1,6 +1,8 @@
 package com.mashup.twotoo.presenter.history.navigation
 
 import android.annotation.SuppressLint
+import android.util.Log
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.navigation.*
@@ -8,11 +10,13 @@ import androidx.navigation.compose.composable
 import com.mashup.twotoo.presenter.di.daggerViewModel
 import com.mashup.twotoo.presenter.history.HistoryRoute
 import com.mashup.twotoo.presenter.history.datail.HistoryDetailRoute
+import com.mashup.twotoo.presenter.history.detailImage.DetailImageRoute
 import com.mashup.twotoo.presenter.history.di.HistoryComponentProvider
 import com.mashup.twotoo.presenter.home.model.HomeGoalAchievePartnerAndMeUiModel
 import com.mashup.twotoo.presenter.navigation.NavigationRoute
 import com.mashup.twotoo.presenter.util.MoshiUtils
 import com.mashup.twotoo.presenter.util.componentProvider
+import com.mashup.twotoo.presenter.util.toIncodeUrl
 
 fun NavController.navigateToHistory(challengeNo: Int, homeGoalAchievePartnerAndMeUiModel: HomeGoalAchievePartnerAndMeUiModel? = null) {
     if (homeGoalAchievePartnerAndMeUiModel != null) {
@@ -25,6 +29,10 @@ fun NavController.navigateToHistory(challengeNo: Int, homeGoalAchievePartnerAndM
 
 private fun NavController.navigateToHistoryDetail(commitNo: Int) {
     this.navigate(route = "${NavigationRoute.HistoryGraph.HistoryDetailScreen.route}/$commitNo")
+}
+
+private fun NavController.navigateToDetailImageScreen(url: String) {
+    this.navigate(route = "${NavigationRoute.HistoryGraph.DetailImageScreen.route}/${url.toIncodeUrl()}")
 }
 
 @SuppressLint("UnrememberedGetBackStackEntry")
@@ -84,7 +92,25 @@ fun NavGraphBuilder.historyGraph(navController: NavController) {
             HistoryDetailRoute(
                 commitNo = commitNo,
                 historyViewModel = historyViewModel,
-                onClickBackButton = { navController.popBackStack() },
+                onClickBackButton = navController::popBackStack,
+                onClickImage = navController::navigateToDetailImageScreen,
+            )
+        }
+
+        composable(
+            route = "${NavigationRoute.HistoryGraph.DetailImageScreen.route}/{url}",
+            arguments = listOf(
+                navArgument("url") { type = NavType.StringType },
+            ),
+        ) { navBackStackEntry: NavBackStackEntry ->
+
+            val url = navBackStackEntry.arguments?.getString("url") ?: ""
+            SideEffect {
+                Log.d("Exception", "historyGraph: $url")
+            }
+            DetailImageRoute(
+                url = url,
+                onClickBackButton = navController::popBackStack,
             )
         }
     }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/navigation/TopLevelDestination.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/navigation/TopLevelDestination.kt
@@ -71,6 +71,7 @@ sealed class NavigationRoute(val route: String) {
     object HistoryGraph : NavigationRoute("history") {
         object HistoryScreen : NavigationRoute("history/screen")
         object HistoryDetailScreen : NavigationRoute("detail/screen")
+        object DetailImageScreen : NavigationRoute("detail/image/screen")
     }
 
     object GuideGraph : NavigationRoute("guide") {

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/util/IncodingImageUrl.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/util/IncodingImageUrl.kt
@@ -1,0 +1,8 @@
+package com.mashup.twotoo.presenter.util
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+fun String.toIncodeUrl(): String {
+    return URLEncoder.encode(this, StandardCharsets.UTF_8.toString())
+}

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/util/SaveImage.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/util/SaveImage.kt
@@ -1,0 +1,50 @@
+package com.mashup.twotoo.presenter.util
+
+import android.content.ContentValues
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStream
+
+fun saveBitmapToStorage(
+    context: Context,
+    bitmap: Bitmap,
+    title: String,
+    onSuccessToSave: () -> Unit,
+    onFailToSave: () -> Unit,
+    mimeType: String = "image/jpeg",
+    directory: String = Environment.DIRECTORY_PICTURES,
+    mediaContentUri: Uri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+) {
+    val imageOutStream: OutputStream?
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        val values = ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, title)
+            put(MediaStore.Images.Media.MIME_TYPE, mimeType)
+            put(MediaStore.Images.Media.RELATIVE_PATH, directory)
+        }
+
+        context.contentResolver.run {
+            val uri = this.insert(mediaContentUri, values) ?: run {
+                onFailToSave()
+                return
+            }
+            imageOutStream = openOutputStream(uri) ?: run {
+                onFailToSave()
+                return
+            }
+        }
+    } else {
+        val imagePath = Environment.getExternalStoragePublicDirectory(directory).absolutePath
+        val image = File(imagePath, title)
+        imageOutStream = FileOutputStream(image)
+    }
+    imageOutStream.use { bitmap.compress(Bitmap.CompressFormat.JPEG, 100, it) }.run {
+        onSuccessToSave()
+    }
+}

--- a/presenter/src/main/res/values/string.xml
+++ b/presenter/src/main/res/values/string.xml
@@ -144,6 +144,9 @@
     <string name="historyDetailTitle">%s의 기록</string>
     <string name="historyDetailCreatedTime">입력 시간 : %s</string>
     <string name="complimentFromPartner">%s의 칭찬 한마디</string>
+    <string name="saveImage">저장하기</string>
+    <string name="saveImageSuccessToastText">사진 저장에 성공했습니다</string>
+    <string name="saveImageErrorToastText">사진 저장에 실패했습니다</string>
 
     <!-- button -->
     <string name="button_confirm">확인</string>


### PR DESCRIPTION
## 🔥 관련 이슈

close #266

## 🔥 PR Point
- 이미지 줌인 아웃 추가
- 이미지 더블클릭시 줌인 스케일 초기화
- 이미지저장 로직 추가
- navigation에서 url형식으로 네비게이션할 경우 encoding로직추가
- 이미지 디테일 스크린 추가

## 🔥 To Reviewers
- 이미지 줌인 줌아웃은 https://stackoverflow.com/questions/69386614/how-to-implement-zoom-and-pan-on-an-image-in-jetpack-compose 이 링크를 통해 구현했습니다
- navigation을 사용할때 route에 url형식이 들어가면  exception이 발생해서 인코딩하는 함수를 추가했습니다https://velog.io/@mraz3068/Compose-Navigation-Argument-%EB%A1%9C-url-%EC%A0%84%EB%8B%AC%ED%95%98%EA%B8%B0
- 사진 저장로직은 https://androidexplained.github.io/android/android11/scoped-storage/2020/09/29/file-saving-android-11.html 다음을 참고했습니다
- ImageView에서 bitmap은 capturable 라이브러리를 통해서 얻었습니다.

## Todo
- [ ] 생각해보니 이미지 주소로 그대로 저장해서 변경해야할듯[아직안함]

## 📷 Screenshot
|기능|스크린샷|
|:---|---|
|이미지 저장|https://github.com/mash-up-kr/TwoToo_Android/assets/62296097/f53f556f-59a9-48b6-a838-344f40206a54|





