### PR TITLE
닉네임 변경 페이지 추가

### DIFF
--- a/data/src/main/java/com/mashup/twotoo/datasource/remote/user/UserApi.kt
+++ b/data/src/main/java/com/mashup/twotoo/datasource/remote/user/UserApi.kt
@@ -34,4 +34,9 @@ interface UserApi {
 
     @DELETE("/user/signOut")
     suspend fun signOut(): NetworkResult<Boolean>
+
+    @PATCH("/user/changeNickname")
+    suspend fun changeNickName(
+        @Body userNickName: UserNickNameRequest
+    ): NetworkResult<UserInfoResponse>
 }

--- a/data/src/main/java/com/mashup/twotoo/datasource/remote/user/UserDataSource.kt
+++ b/data/src/main/java/com/mashup/twotoo/datasource/remote/user/UserDataSource.kt
@@ -38,4 +38,10 @@ class UserDataSource @Inject constructor(
     suspend fun signOut(): NetworkResult<Boolean> {
         return userApi.signOut()
     }
+
+    suspend fun changeNickname(
+        userNickNameRequest: UserNickNameRequest,
+    ): NetworkResult<UserInfoResponse> {
+        return userApi.changeNickName(userNickNameRequest)
+    }
 }

--- a/data/src/main/java/com/mashup/twotoo/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/twotoo/repository/UserRepositoryImpl.kt
@@ -48,4 +48,10 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun signOut(): NetworkResult<Boolean> {
         return userDataSource.signOut()
     }
+
+    override suspend fun changeNickname(userNickNameDomainModel: UserNickNameDomainModel): NetworkResult<UserInfoDomainModel> {
+        return userDataSource.changeNickname(userNickNameDomainModel.toDataModel()).map { userInfoResponse ->
+            userInfoResponse.toDomainModel()
+        }
+    }
 }

--- a/domain/src/main/java/repository/UserRepository.kt
+++ b/domain/src/main/java/repository/UserRepository.kt
@@ -14,4 +14,5 @@ interface UserRepository {
     suspend fun getUserInfo(): NetworkResult<UserInfoDomainModel>
     suspend fun deletePartner(): NetworkResult<Boolean>
     suspend fun signOut(): NetworkResult<Boolean>
+    suspend fun changeNickname(userNickNameDomainModel: UserNickNameDomainModel): NetworkResult<UserInfoDomainModel>
 }

--- a/domain/src/main/java/usecase/user/ChangeNicknameUseCase.kt
+++ b/domain/src/main/java/usecase/user/ChangeNicknameUseCase.kt
@@ -1,0 +1,15 @@
+package usecase.user
+
+import model.user.UserInfoDomainModel
+import model.user.UserNickNameDomainModel
+import repository.UserRepository
+import util.NetworkResult
+import javax.inject.Inject
+
+class ChangeNicknameUseCase @Inject constructor(
+    private val userRepository: UserRepository
+) {
+    suspend operator fun invoke(userNickNameDomainModel: UserNickNameDomainModel): NetworkResult<UserInfoDomainModel> {
+        return userRepository.changeNickname(userNickNameDomainModel)
+    }
+}

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/mypage/MyPage.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/mypage/MyPage.kt
@@ -1,6 +1,7 @@
 package com.mashup.twotoo.presenter.mypage
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Divider
@@ -39,6 +41,7 @@ import com.mashup.twotoo.presenter.home.ongoing.components.HomeGoalCount
 import com.mashup.twotoo.presenter.mypage.components.MyPageItemList
 import com.mashup.twotoo.presenter.mypage.model.GuideUrlItem
 import com.mashup.twotoo.presenter.mypage.model.MyPageItem
+import com.mashup.twotoo.presenter.navigation.NavigationRoute
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
@@ -107,6 +110,7 @@ fun MyPageRoute(
         state = state,
         isMyPageDialogVisible = isMyPageDialogVisible,
         myPageDialogContent = myPageDialogContent,
+        navigateToChangeNickName = { route -> userViewModel.navigateToRoute(route) },
         navigateToGuide = { route ->
             when (route) {
                 MyPageItem.DeletePartner.route -> { userViewModel.openDeletePartnerConfirmDialog() }
@@ -141,6 +145,7 @@ fun MyPageScreen(
     isMyPageDialogVisible: Boolean = false,
     myPageDialogContent: DialogContent = DialogContent.default,
     navigateToGuide: (String) -> Unit,
+    navigateToChangeNickName: (String) -> Unit
 ) {
     Column(
         modifier = modifier.fillMaxSize(),
@@ -166,12 +171,13 @@ fun MyPageScreen(
         Spacer(modifier = Modifier.height(14.dp))
         Row(
             modifier = Modifier
-                .width(66.dp)
+                .clickable { navigateToChangeNickName(NavigationRoute.NickNameSettingGraph.route) }
                 .height(34.dp)
                 .background(
                     color = Color.White,
                     shape = TwoTooTheme.shape.small,
-                ),
+                )
+                .padding(horizontal = 10.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center,
         ) {
@@ -179,6 +185,12 @@ fun MyPageScreen(
                 text = state.homeGoalCountUiModel.myName ?: "",
                 style = TwoTooTheme.typography.headLineNormal18,
                 color = TwoTooTheme.color.mainBrown,
+            )
+            Spacer(modifier = modifier.width(10.dp))
+            TwoTooImageView(
+                modifier = Modifier.size(16.dp),
+                model = R.drawable.ic_edit,
+                previewPlaceholder = R.drawable.ic_edit,
             )
         }
         Spacer(modifier = Modifier.height(28.dp))
@@ -204,6 +216,6 @@ fun MyPageScreen(
 @Composable
 fun PreviewMyPageScreen() {
     TwoTooTheme {
-        MyPageScreen(state = UserState(HomeGoalCountUiModel.default), navigateToGuide = {})
+        MyPageScreen(state = UserState(HomeGoalCountUiModel.default), navigateToChangeNickName = {}, navigateToGuide = {})
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/mypage/navigation/UserNavigation.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/mypage/navigation/UserNavigation.kt
@@ -1,5 +1,6 @@
 package com.mashup.twotoo.presenter.mypage.navigation
 
+import android.util.Log
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -49,6 +50,9 @@ fun NavGraphBuilder.userGraph(navController: NavController) {
                                     }
                                 },
                             )
+                        }
+                        NavigationRoute.NickNameSettingGraph.route -> {
+                            navController.navigateToOnNickNameSetting("mypage")
                         }
                         else -> { navController.navigateToGuide(route) } }
                 },

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/nickname/NickNameSideEffect.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/nickname/NickNameSideEffect.kt
@@ -4,4 +4,5 @@ sealed class NickNameSideEffect {
     data class NavigateToSendInvitation(val nickname: String) : NickNameSideEffect()
     data class ToastMessage(val msg: String) : NickNameSideEffect()
     object NavigateToHome : NickNameSideEffect()
+    object NavigateToMyPage : NickNameSideEffect()
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/nickname/NickNameViewModel.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/nickname/NickNameViewModel.kt
@@ -9,13 +9,15 @@ import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
+import usecase.user.ChangeNicknameUseCase
 import usecase.user.SetNickNameUseCase
 import util.onError
 import util.onSuccess
 import javax.inject.Inject
 
 class NickNameViewModel @Inject constructor(
-    private val setNickNameUseCase: SetNickNameUseCase
+    private val setNickNameUseCase: SetNickNameUseCase,
+    private val changeNicknameUseCase: ChangeNicknameUseCase
 ) : ViewModel(), ContainerHost<NickNameState, NickNameSideEffect> {
     override val container = container<NickNameState, NickNameSideEffect>(NickNameState())
 
@@ -41,6 +43,22 @@ class NickNameViewModel @Inject constructor(
             } else {
                 postSideEffect(NickNameSideEffect.NavigateToSendInvitation(userNickName))
             }
+        }.onError { code, message ->
+            message?.let { msg ->
+                Log.d(TAG, "viewModel: $message")
+                toastMessage(msg)
+            }
+        }
+    }
+
+    fun changeNickname(userNickName: String) = intent {
+        changeNicknameUseCase(
+            UserNickNameDomainModel(
+                nickname = userNickName,
+                partnerNo = null,
+            ),
+        ).onSuccess {
+            postSideEffect(NickNameSideEffect.NavigateToMyPage)
         }.onError { code, message ->
             message?.let { msg ->
                 Log.d(TAG, "viewModel: $message")

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/nickname/di/NickNameSettingModule.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/nickname/di/NickNameSettingModule.kt
@@ -3,9 +3,8 @@ package com.mashup.twotoo.presenter.nickname.di
 import com.mashup.twotoo.presenter.nickname.NickNameViewModel
 import dagger.Module
 import dagger.Provides
-import usecase.user.GetPreferenceUserInfoUseCase
+import usecase.user.ChangeNicknameUseCase
 import usecase.user.SetNickNameUseCase
-import usecase.user.SetPreferenceUserInfoUseCase
 import javax.inject.Scope
 
 @Module
@@ -14,10 +13,12 @@ class NickNameSettingModule {
     @Provides
     @NickNameSettingScope
     fun provideViewModel(
-        setNickNameUseCase: SetNickNameUseCase
+        setNickNameUseCase: SetNickNameUseCase,
+        changeNicknameUseCase: ChangeNicknameUseCase
     ): NickNameViewModel {
         return NickNameViewModel(
-            setNickNameUseCase = setNickNameUseCase
+            setNickNameUseCase = setNickNameUseCase,
+            changeNicknameUseCase = changeNicknameUseCase,
         )
     }
 }

--- a/presenter/src/main/java/com/mashup/twotoo/presenter/nickname/navigation/NickNameSettingNavigation.kt
+++ b/presenter/src/main/java/com/mashup/twotoo/presenter/nickname/navigation/NickNameSettingNavigation.kt
@@ -3,7 +3,9 @@ package com.mashup.twotoo.presenter.nickname.navigation
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import androidx.navigation.navOptions
 import androidx.navigation.navigation
 import com.mashup.twotoo.presenter.di.daggerViewModel
@@ -14,21 +16,28 @@ import com.mashup.twotoo.presenter.nickname.NickNameSettingRoute
 import com.mashup.twotoo.presenter.nickname.di.NickNameSettingComponentProvider
 import com.mashup.twotoo.presenter.util.componentProvider
 
-fun NavController.navigateToOnNickNameSetting(navOptions: NavOptions? = null) {
-    this.navigate(route = NavigationRoute.NickNameSettingGraph.route, navOptions = navOptions)
+fun NavController.navigateToOnNickNameSetting(startRoute: String = "", navOptions: NavOptions? = null) {
+    this.navigate(route = "${NavigationRoute.NickNameSettingGraph.NickNameSettingScreen.route}/$startRoute", navOptions = navOptions)
 }
 fun NavGraphBuilder.nickNameSettingGraph(
     navController: NavController
 ) {
-    navigation(startDestination = NavigationRoute.NickNameSettingGraph.NickNameSettingScreen.route, route = NavigationRoute.NickNameSettingGraph.route) {
+    navigation(
+        startDestination = "${NavigationRoute.NickNameSettingGraph.NickNameSettingScreen.route}/{startRoute}",
+        route = NavigationRoute.NickNameSettingGraph.route,
+    ) {
         composable(
-            route = NavigationRoute.NickNameSettingGraph.NickNameSettingScreen.route,
-        ) {
+            route = "${NavigationRoute.NickNameSettingGraph.NickNameSettingScreen.route}/{startRoute}",
+            arguments = listOf(
+                navArgument("startRoute") { type = NavType.StringType },
+            ),
+        ) { navBackStackEntry ->
             val nickNameSettingComponent = componentProvider<NickNameSettingComponentProvider>().provideNickNameSettingComponent()
             val nickNameViewModel = daggerViewModel {
                 nickNameSettingComponent.getViewModel()
             }
-            NickNameSettingRoute(nickNameViewModel) { route ->
+            val startRoute = navBackStackEntry.arguments?.getString("startRoute") ?: ""
+            NickNameSettingRoute(nickNameViewModel, startRoute) { route ->
                 when (route) {
                     NavigationRoute.HomeGraph.HomeScreen.route -> {
                         navController.navigateToHome(
@@ -47,6 +56,9 @@ fun NavGraphBuilder.nickNameSettingGraph(
                                 }
                             },
                         )
+                    }
+                    NavigationRoute.UserGraph.UserScreen.route -> {
+                        navController.popBackStack()
                     }
                 }
             }

--- a/presenter/src/main/res/drawable/ic_edit.xml
+++ b/presenter/src/main/res/drawable/ic_edit.xml
@@ -1,0 +1,34 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="17dp"
+    android:height="18dp"
+    android:viewportWidth="17"
+    android:viewportHeight="18">
+  <group>
+    <clip-path
+        android:pathData="M0,0.886h17v16.227h-17z"/>
+    <path
+        android:pathData="M3.267,11.591L2.591,14.296L5.295,13.62L13.129,5.786C13.657,5.258 13.657,4.402 13.129,3.873L13.013,3.757C12.485,3.229 11.629,3.229 11.101,3.757L3.267,11.591Z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.35227"
+        android:fillColor="#00000000"
+        android:strokeColor="#A09E9C"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M3.267,11.591L2.591,14.295L5.295,13.619L12.057,6.858L10.028,4.83L3.267,11.591Z"
+        android:fillColor="#A09E9C"/>
+    <path
+        android:pathData="M10.028,4.83L12.057,6.858"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.35227"
+        android:fillColor="#00000000"
+        android:strokeColor="#A09E9C"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M8.676,14.295H14.085"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.35227"
+        android:fillColor="#00000000"
+        android:strokeColor="#A09E9C"
+        android:strokeLineCap="round"/>
+  </group>
+</vector>

--- a/presenter/src/main/res/values/string.xml
+++ b/presenter/src/main/res/values/string.xml
@@ -89,6 +89,7 @@
     <string name="onboarding_pager_2">상대방에게 귀여운\n찌르기로 푸시해보세요.</string>
     <string name="onboarding_pager_3">서로 인증하고 응원하며\n목표를 달성해보세요.</string>
     <string name="nickname_setting">투투에서 사용할\n닉네임을 입력해주세요</string>
+    <string name="nickname_change">변경할 닉네임을\n입력해주세요</string>
     <string name="nickname_setting_hint">4글자 이내 닉네임을 입력해주세요</string>
     <string name="nickname">닉네임</string>
 


### PR DESCRIPTION
## 🔥 관련 이슈

close #271 

## 🔥 PR Point

- 마이페이지 아이콘 및 네비게이션 로직 추가
- 기존 닉네임 설정 페이지 재활용 및 로직 수정 

## 🔥 To Reviewers
기존 닉네임 설정 페이지 활용해서 만들었습니다. 
API는 현재 개발버전에만 배포되어있어서 실행할 때 주소값 NetworkModule에서 변경하고 실행해야해요!
(이 부분은 추가로 개발/상용버전 BuildType 나누도록 합시다~!)


## 📷 Screenshot
|기능|스크린샷|
|:---|---|
|닉네임 변경|https://github.com/mash-up-kr/TwoToo_Android/assets/53086454/6581800a-9fb3-4dae-9388-c582f779fe4d|
